### PR TITLE
[WIP] Update README.md to list necessary boost libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Compiling
 ---------
 
 To build, type 'make'. You will need a C++17 compiler (we test with GCC 7.3, GCC 8.3, and Clang
-7.0.1 on Linux, and Xcode 10.2 on Mac OS X) and Boost (we use 1.65.1 or later, built with threads
-enabled).
+7.0.1 on Linux, and Xcode 10.2 on Mac OS X) and Boost (we use 1.65.1 or later, built with the libraries: thread, system, program_options, and iostreams).
 
 Running
 -------


### PR DESCRIPTION
Installing with `make CXX=g++-7`, I was getting some errors like
```
g++-7 -o glasgow_subgraph_solver -pthread -lstdc++fs intermediate/glasgow_subgraph_solver/src/glasgow_subgraph_solver.o libcommon.a -lboost_thread -lboost_system -lboost_program_options -lboost_iostreams -lstdc++fs
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: cannot find -lboost_system
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: cannot find -lboost_program_options
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: cannot find -lboost_iostreams
```
because I installed boost with only the `threads` library, since that was the only library mentioned in the install instructions.