### PR TITLE
Add missing <map> include to input_graph.cc

### DIFF
--- a/src/formats/input_graph.cc
+++ b/src/formats/input_graph.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <map>
 
 #include <boost/bimap.hpp>
 #include <boost/bimap/unordered_set_of.hpp>


### PR DESCRIPTION
Hello,

At D-Wave, we've been using the Glasgow solver internally for a few years to solve subgraph isomorphism problems.  After getting a few requests, I've decided to wrap this library into [minorminer](https://github.com/dwavesystems/minorminer) so that our users can find highly-performant embeddings into our hardware quickly.  I'm quite impressed by the quality and performance of this package, so kudos and thanks very much!

I encountered one minor issue in wrapping your code though.  It seems that `input_graph.cc` is missing an include for the STL `map`.  This doesn't appear to be an issue to your build, presumably because `map` is getting included elsewhere.  But I'm short-cutting your executable and using `sip_decomposer` as a library that gets built into a Python extension.  I could hack around this, but I believe the appropriate place to fix the problem is here.

Thanks and kind regards,

Kelly