### PR TITLE
portable bit manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ To build, type 'make'. You will need a C++17 compiler (we test with GCC 7.3, GCC
 7.0.1 on Linux, and Xcode 10.2 on Mac OS X) and Boost (we use 1.65.1 or later, built with threads
 enabled).
 
+(KB: updating to C++20 requires GCC 10.1, Clang 10.0.0 or later; Xcode 10.2 appears to be fine but I
+have not tested that)
+
 Running
 -------
 

--- a/main.mk
+++ b/main.mk
@@ -16,8 +16,8 @@ override CXXFLAGS += -O3 -march=native -std=c++20 -Isrc/ -W -Wall -g -ggdb3 -pth
 
 ifeq ($(shell uname -s), Linux)
 override LDFLAGS += -pthread -lstdc++fs
-boost_ldlibs := -lboost_thread -lboost_system -lboost_program_options -lboost_iostreams
+boost_ldlibs := -lboost_thread -lboost_system -lboost_program_options -lboost_iostreams -lboost_container
 else
 override LDFLAGS += -pthread
-boost_ldlibs := -lboost_thread-mt -lboost_system-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_iostreams-mt
+boost_ldlibs := -lboost_thread-mt -lboost_system-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_iostreams-mt -lboost_container
 endif

--- a/main.mk
+++ b/main.mk
@@ -12,7 +12,7 @@ SUBMAKEFILES := \
     src/plot_glasgow_solver_proofs.mk \
     src/create_random_graph.mk
 
-override CXXFLAGS += -O3 -march=native -std=c++17 -Isrc/ -W -Wall -g -ggdb3 -pthread
+override CXXFLAGS += -O3 -march=native -std=c++20 -Isrc/ -W -Wall -g -ggdb3 -pthread
 
 ifeq ($(shell uname -s), Linux)
 override LDFLAGS += -pthread -lstdc++fs

--- a/src/formats/input_graph.cc
+++ b/src/formats/input_graph.cc
@@ -13,6 +13,7 @@
 #include <map>
 #include <iterator>
 
+#include <boost/container/allocator.hpp>
 #include <boost/bimap.hpp>
 #include <boost/bimap/unordered_set_of.hpp>
 
@@ -37,7 +38,11 @@ using std::to_string;
 using std::transform;
 using std::vector;
 
-using Names = boost::bimaps::bimap<boost::bimaps::unordered_set_of<int>, boost::bimaps::unordered_set_of<string> >;
+using Names = boost::bimap<
+    boost::bimaps::unordered_set_of<int>,
+    boost::bimaps::unordered_set_of<string>,
+    boost::container::allocator<pair<int, string>>
+>;
 
 namespace
 {

--- a/src/svo_bitset.hh
+++ b/src/svo_bitset.hh
@@ -8,6 +8,20 @@
 #include <cstring>
 #include <limits>
 
+#ifdef USE_PORTABLE_SNIPPETS_BUILTIN
+#include <portable-snippets/builtin/builtin.h>
+int popcount(unsigned long long x) {
+    return psnip_builtin_popcountll(x);
+}
+int countr_zero(unsigned long long x) {
+    return psnip_builtin_ctzll(x);
+}
+#else
+#include <bit>
+using std::popcount;
+using std::countr_zero;
+#endif
+
 class SVOBitset
 {
     private:
@@ -107,17 +121,17 @@ class SVOBitset
         {
             if (! _is_long()) {
                 for (unsigned i = 0 ; i < n_words ; ++i) {
-                    int x = __builtin_ffsll(_data.short_data[i]);
-                    if (0 != x)
-                        return i * bits_per_word + x - 1;
+                    int x = countr_zero(_data.short_data[i]);
+                    if (bits_per_word != x)
+                        return i * bits_per_word + x;
                 }
                 return npos;
             }
             else {
                 for (unsigned i = 0, i_end = n_words ; i < i_end ; ++i) {
-                    int x = __builtin_ffsll(_data.long_data[i]);
-                    if (0 != x)
-                        return i * bits_per_word + x - 1;
+                    int x = countr_zero(_data.short_data[i]);
+                    if (bits_per_word != x)
+                        return i * bits_per_word + x;
                 }
                 return npos;
             }
@@ -194,7 +208,7 @@ class SVOBitset
             unsigned result = 0;
             const BitWord * b = (_is_long() ? _data.long_data : _data.short_data);
             for (unsigned i = 0, i_end = n_words ; i < i_end ; ++i)
-                result += __builtin_popcountll(b[i]);
+                result += popcount(b[i]);
 
             return result;
         }

--- a/src/svo_bitset.hh
+++ b/src/svo_bitset.hh
@@ -9,12 +9,14 @@
 #include <limits>
 
 #ifdef USE_PORTABLE_SNIPPETS_BUILTIN
+namespace {
 #include <portable-snippets/builtin/builtin.h>
 int popcount(unsigned long long x) {
     return psnip_builtin_popcountll(x);
 }
 int countr_zero(unsigned long long x) {
     return psnip_builtin_ctzll(x);
+}
 }
 #else
 #include <bit>

--- a/src/svo_bitset.hh
+++ b/src/svo_bitset.hh
@@ -119,22 +119,12 @@ class SVOBitset
 
         auto find_first() const -> unsigned
         {
-            if (! _is_long()) {
-                for (unsigned i = 0 ; i < n_words ; ++i) {
-                    int x = countr_zero(_data.short_data[i]);
-                    if (bits_per_word != x)
-                        return i * bits_per_word + x;
-                }
-                return npos;
+            const BitWord * b = (_is_long() ? _data.long_data : _data.short_data);
+            for (unsigned i = 0 ; i < n_words ; ++i) {
+                if (0 != b[i]) // test the input to countr_zero because on some systems, the output is undefined at b[i]=0
+                    return i * bits_per_word + countr_zero(b[i]);
             }
-            else {
-                for (unsigned i = 0, i_end = n_words ; i < i_end ; ++i) {
-                    int x = countr_zero(_data.short_data[i]);
-                    if (bits_per_word != x)
-                        return i * bits_per_word + x;
-                }
-                return npos;
-            }
+            return npos;
         }
 
         auto reset(int a) -> void


### PR DESCRIPTION
This one might be somewhat controversial.  I'd like to support a variety of compilers and platforms (specifically MSVC which doesn't define `__builtin_*` and ARM which doesn't even have a popcount instruction), and the [portable snippets](https://github.com/nemequ/portable-snippets) package handles this beautifully.

This patch inserts a compile-time check for inclusion of the `builtin.h` header file from the above, which provides `__builtin_popcount` and `__builtin_ffsll`.  The approach I'm taking in [minorminer](https://github.com/dwavesystems/minorminer/pull/221) is to haul `portable-snippets` in as a submodule, and make it appear as a system-level header.  Working with submodules is a little obnoxious, but I'd already bit that bullet when incorporating `glasgow-subgraph-solver` as a submodule.

If you're interested in expanding your build system to take advantage of this `#include` you'd probably want to do something similar or perhaps just crib the CC0-licenced `builtin.h` file directly.  That said, I'm bypassing your build system, so these few lines are sufficient for me.  I'm happy to entertain shed-painting (is `GLASGOW_SUBGRAPH_SOLVER_PORTABLE_BUILTINS` really the right name for this) and different approaches to the problem.

Thanks!