### PR TITLE
VeriPB3.0 syntax prooflogging added

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04, macos-13, macos-14 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, macos-14, macos-latest ] # macos-14 and macos-15 as of 10/25
 
     steps:
     - name: Telling you what the matrix is

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,22 +29,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-      if: startsWith(matrix.os, 'ubuntu')
-
-    - name: Fetch VeriPB
-      run: git -c core.hooksPath=/dev/null clone --depth 1 https://gitlab.com/MIAOresearch/software/VeriPB.git
-
-    - name: Install VeriPB using pip
-      run: pip install ./VeriPB
-      if: startsWith(matrix.os, 'ubuntu')
-
-    - name: Install VeriPB using pipx
-      run: env CPPFLAGS="-I`brew --prefix gmp`/include" LDFLAGS="-L`brew --prefix gmp`/lib" pipx install ./VeriPB
-      if: startsWith(matrix.os, 'macos')
+    - name: Install VeriPB using cargo
+      run: cargo install --path ./VeriPB
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Fetch VeriPB
+      run: git -c core.hooksPath=/dev/null clone --depth 1 https://gitlab.com/MIAOresearch/software/VeriPB.git
+
     - name: Install VeriPB using cargo
       run: cargo install --path ./VeriPB
 

--- a/gss/innards/proof.cc
+++ b/gss/innards/proof.cc
@@ -108,7 +108,7 @@ auto Proof::create_cp_variable(int pattern_vertex, int target_size,
     for (int i = 0; i < target_size; ++i)
         _imp->variable_mappings.emplace(pair{pattern_vertex, i}, pattern_name(pattern_vertex) + "_" + target_name(i));
 
-    _imp->model_stream << "% vertex " << pattern_vertex << " domain\n";
+    _imp->model_stream << "* vertex " << pattern_vertex << " domain\n";
     stringstream al1_constraint;
     for (int i = 0; i < target_size; ++i)
         al1_constraint << "1 x" << _imp->variable_mappings[{pattern_vertex, i}] << " ";
@@ -129,7 +129,7 @@ auto Proof::create_cp_variable(int pattern_vertex, int target_size,
 auto Proof::create_injectivity_constraints(int pattern_size, int target_size) -> void
 {
     for (int v = 0; v < target_size; ++v) {
-        _imp->model_stream << "% injectivity on value " << v << '\n';
+        _imp->model_stream << "* injectivity on value " << v << '\n';
         stringstream injectivity_constraint;
 
         for (int p = 0; p < pattern_size; ++p) {
@@ -146,7 +146,7 @@ auto Proof::create_injectivity_constraints(int pattern_size, int target_size) ->
 
 auto Proof::create_forbidden_assignment_constraint(int p, int t) -> void
 {
-    _imp->model_stream << "% forbidden assignment\n";
+    _imp->model_stream << "* forbidden assignment\n";
     _imp->model_stream << "1 ~x" << _imp->variable_mappings[pair{p, t}] << " >= 1 ;\n";
     ++_imp->nb_constraints;
     _imp->eliminations.emplace(pair{p, t}, _imp->nb_constraints);
@@ -154,7 +154,7 @@ auto Proof::create_forbidden_assignment_constraint(int p, int t) -> void
 
 auto Proof::start_adjacency_constraints_for(int p, int t) -> void
 {
-    _imp->model_stream << "% adjacency " << p << " maps to " << t << '\n';
+    _imp->model_stream << "* adjacency " << p << " maps to " << t << '\n';
 }
 
 auto Proof::create_adjacency_constraint(int p, int q, int t, const vector<int> & uu, const vector<int> & cancel,
@@ -193,7 +193,7 @@ auto Proof::finalise_model() -> void
 {
     unique_ptr<ostream> f = make_unique<ofstream>(_imp->opb_filename);
 
-    *f << "% #variable= " << (_imp->variable_mappings.size() + _imp->binary_variable_mappings.size() + _imp->connected_variable_mappings.size() + _imp->connected_variable_mappings_aux.size())
+    *f << "* #variable= " << (_imp->variable_mappings.size() + _imp->binary_variable_mappings.size() + _imp->connected_variable_mappings.size() + _imp->connected_variable_mappings_aux.size())
        << " #constraint= " << _imp->nb_constraints << ";\n";
     copy(istreambuf_iterator<char>{_imp->model_prelude_stream}, istreambuf_iterator<char>{}, ostreambuf_iterator<char>{*f});
     _imp->model_prelude_stream.clear();
@@ -205,7 +205,7 @@ auto Proof::finalise_model() -> void
 
     _imp->proof_stream = make_unique<ofstream>(_imp->log_filename);
 
-    *_imp->proof_stream << "pseudo-Boolean proof version 3.0;\n";
+    *_imp->proof_stream << "pseudo-Boolean proof version 3.0\n";
 
     *_imp->proof_stream << "f " << _imp->nb_constraints << " ;\n";
     _imp->proof_line += _imp->nb_constraints;
@@ -279,7 +279,7 @@ auto Proof::recover_adjacency_lines(int g, int p, int n, int t) -> void
     auto it = _imp->adjacency_lines.find(tuple{g, p, n, t});
     if (it != _imp->adjacency_lines.end() && 0 == get<1>(it->second)) {
         *_imp->proof_stream << "setlvl 0;\n";
-        *_imp->proof_stream << "red " << get<2>(it->second) << ": : ;\n";//TODO: check if this is correct
+        *_imp->proof_stream << "red " << get<2>(it->second) << ";\n";
         get<1>(it->second) = ++_imp->proof_line;
         *_imp->proof_stream << "setlvl " << _imp->active_level << ";\n";
     }
@@ -914,7 +914,7 @@ auto Proof::create_binary_variable(int vertex,
 auto Proof::create_objective(int n, optional<int> d) -> void
 {
     if (d) {
-        _imp->model_stream << "% objective\n";
+        _imp->model_stream << "* objective\n";
         for (int v = 0; v < n; ++v)
             _imp->model_stream << "1 x" << _imp->binary_variable_mappings[v] << " ";
         _imp->model_stream << ">= " << *d << ";\n";
@@ -945,7 +945,7 @@ auto Proof::create_non_edge_constraint(int p, int q) -> void
 auto Proof::create_null_decision_bound(int p, int t, optional<int> d) -> void
 {
     if (d) {
-        _imp->model_stream << "% objective\n";
+        _imp->model_stream << "* objective\n";
         for (int v = 0; v < p; ++v)
             _imp->model_stream << " 1 x" << _imp->variable_mappings[pair{v, t}] << " ";
         _imp->model_stream << ">= " << *d << " ;\n";
@@ -1235,7 +1235,7 @@ auto Proof::rewrite_mcs_objective(int pattern_size) -> void
 
 auto Proof::create_connected_constraints(int p, int t, const function<auto(int, int)->bool> & adj) -> void
 {
-    _imp->model_stream << "% selected vertices must be connected, walk 1\n";
+    _imp->model_stream << "* selected vertices must be connected, walk 1\n";
     int mapped_to_null = t;
     int cnum = _imp->variable_mappings.size();
 
@@ -1263,7 +1263,7 @@ auto Proof::create_connected_constraints(int p, int t, const function<auto(int, 
     int last_k = 0;
     for (int k = 2 ; ; k *= 2) {
         last_k = k;
-        _imp->model_stream << "% selected vertices must be connected, walk " << k << '\n';
+        _imp->model_stream << "* selected vertices must be connected, walk " << k << '\n';
         for (int v = 0; v < p; ++v)
             for (int w = 0; w < v; ++w) {
                 string n = "conn" + to_string(k) + "_" + to_string(v) + "_" + to_string(w);
@@ -1310,7 +1310,7 @@ auto Proof::create_connected_constraints(int p, int t, const function<auto(int, 
             break;
     }
 
-    _imp->model_stream << "% if two vertices are used, they must be connected\n";
+    _imp->model_stream << "* if two vertices are used, they must be connected\n";
     for (int v = 0; v < p; ++v)
         for (int w = 0; w < v; ++w) {
             _imp->model_stream << "1 x" << _imp->variable_mappings[pair{v, mapped_to_null}]

--- a/gss/innards/proof.cc
+++ b/gss/innards/proof.cc
@@ -72,6 +72,7 @@ struct Proof::Imp
     long proof_line = 0;
     int largest_level_set = 0;
     int active_level = 0;
+    
 
     bool clique_encoding = false;
     bool doing_mcs_by_clique = false;
@@ -145,7 +146,7 @@ auto Proof::create_injectivity_constraints(int pattern_size, int target_size) ->
 
 auto Proof::create_forbidden_assignment_constraint(int p, int t) -> void
 {
-    _imp->model_stream << "* forbidden assignment\n";
+    _imp->model_stream << "% forbidden assignment\n";
     _imp->model_stream << "1 ~x" << _imp->variable_mappings[pair{p, t}] << " >= 1 ;\n";
     ++_imp->nb_constraints;
     _imp->eliminations.emplace(pair{p, t}, _imp->nb_constraints);
@@ -204,9 +205,9 @@ auto Proof::finalise_model() -> void
 
     _imp->proof_stream = make_unique<ofstream>(_imp->log_filename);
 
-    *_imp->proof_stream << "pseudo-Boolean proof version 2.0\n";
+    *_imp->proof_stream << "pseudo-Boolean proof version 3.0\n";
 
-    *_imp->proof_stream << "f " << _imp->nb_constraints << " 0\n";
+    *_imp->proof_stream << "f " << _imp->nb_constraints << " ;\n";
     _imp->proof_line += _imp->nb_constraints;
 
     if (! *_imp->proof_stream)
@@ -215,12 +216,12 @@ auto Proof::finalise_model() -> void
 
 auto Proof::finish_unsat_proof() -> void
 {
-    *_imp->proof_stream << "* asserting that we've proved unsat\n";
-    *_imp->proof_stream << "u >= 1 ;\n";
+    *_imp->proof_stream << "% asserting that we've proved unsat\n";
+    *_imp->proof_stream << "rup >= 1 ;\n";
     ++_imp->proof_line;
-    *_imp->proof_stream << "output NONE\n"
-                        << "conclusion UNSAT : -1\n"
-                        << "end pseudo-Boolean proof\n";
+    *_imp->proof_stream << "output NONE;\n"
+                        << "conclusion UNSAT : -1;\n"
+                        << "end pseudo-Boolean proof;\n";
 }
 
 auto Proof::finish_sat_proof() -> void
@@ -239,7 +240,7 @@ auto Proof::finish_unknown_proof() -> void
 
 auto Proof::finish_optimisation_proof(int size) -> void
 {
-    *_imp->proof_stream << "u" << _imp->objective_sum.str() << " >= " << size << ";\n";
+    *_imp->proof_stream << "rup" << _imp->objective_sum.str() << " >= " << size << ";\n";
     *_imp->proof_stream << "output NONE\n"
         << "conclusion BOUNDS " << size << " " << size << '\n'
         << "end pseudo-Boolean proof\n";
@@ -247,7 +248,7 @@ auto Proof::finish_optimisation_proof(int size) -> void
 
 auto Proof::failure_due_to_pattern_bigger_than_target() -> void
 {
-    *_imp->proof_stream << "* failure due to the pattern being bigger than the target\n";
+    *_imp->proof_stream << "% failure due to the pattern being bigger than the target\n";
 
     for (auto & [id, _] : _imp->injectivity_constraints) {
         recover_injectivity_constraint(id);
@@ -255,7 +256,7 @@ auto Proof::failure_due_to_pattern_bigger_than_target() -> void
     }
 
     // we get a hall violator by adding up all of the things
-    *_imp->proof_stream << "p";
+    *_imp->proof_stream << "pol";
     bool first = true;
 
     for (auto & [_, data] : _imp->at_least_one_value_constraints) {
@@ -269,7 +270,7 @@ auto Proof::failure_due_to_pattern_bigger_than_target() -> void
 
     for (auto & [_, data] : _imp->injectivity_constraints)
         *_imp->proof_stream << " " << get<1>(data) << " +";
-    *_imp->proof_stream << " 0\n";
+    *_imp->proof_stream << " ;\n";
     ++_imp->proof_line;
 }
 
@@ -277,10 +278,10 @@ auto Proof::recover_adjacency_lines(int g, int p, int n, int t) -> void
 {
     auto it = _imp->adjacency_lines.find(tuple{g, p, n, t});
     if (it != _imp->adjacency_lines.end() && 0 == get<1>(it->second)) {
-        *_imp->proof_stream << "# 0\n";
-        *_imp->proof_stream << "red " << get<2>(it->second) << " ; ;\n";
+        *_imp->proof_stream << "setlvl 0;\n";
+        *_imp->proof_stream << "red " << get<2>(it->second) << ": : ;\n";//TODO: check if this is correct
         get<1>(it->second) = ++_imp->proof_line;
-        *_imp->proof_stream << "# " << _imp->active_level << '\n';
+        *_imp->proof_stream << "setlvl " << _imp->active_level << ";\n";
     }
 }
 
@@ -288,10 +289,10 @@ auto Proof::recover_injectivity_constraint(int p) -> void
 {
     auto it = _imp->injectivity_constraints.find(p);
     if (it != _imp->injectivity_constraints.end() && 0 == get<1>(it->second)) {
-        *_imp->proof_stream << "# 0\n";
+        *_imp->proof_stream << "setlvl 0;\n";
         *_imp->proof_stream << "ia " << get<2>(it->second) << " ;\n";
         get<1>(it->second) = ++_imp->proof_line;
-        *_imp->proof_stream << "# " << _imp->active_level << '\n';
+        *_imp->proof_stream << "setlvl " << _imp->active_level << ";\n";
     }
 }
 
@@ -299,10 +300,10 @@ auto Proof::recover_at_least_one_constraint(int p) -> void
 {
     auto it = _imp->at_least_one_value_constraints.find(p);
     if (it != _imp->at_least_one_value_constraints.end() && 0 == get<1>(it->second)) {
-        *_imp->proof_stream << "# 0\n";
+        *_imp->proof_stream << "setlvl 0;\n";
         *_imp->proof_stream << "ia " << get<2>(it->second) << " ;\n";
         get<1>(it->second) = ++_imp->proof_line;
-        *_imp->proof_stream << "# " << _imp->active_level << '\n';
+        *_imp->proof_stream << "setlvl " << _imp->active_level << ";\n";
     }
 }
 
@@ -310,20 +311,20 @@ auto Proof::recover_at_most_one_constraint(int p) -> void
 {
     auto it = _imp->at_most_one_value_constraints.find(p);
     if (it != _imp->at_most_one_value_constraints.end() && 0 == get<1>(it->second)) {
-        *_imp->proof_stream << "# 0\n";
+        *_imp->proof_stream << "setlvl 0;\n";
         *_imp->proof_stream << "ia " << get<2>(it->second) << " ;\n";
         get<1>(it->second) = ++_imp->proof_line;
-        *_imp->proof_stream << "# " << _imp->active_level << '\n';
+        *_imp->proof_stream << "setlvl " << _imp->active_level << ";\n";
     }
 }
 
 auto Proof::need_elimination(int p, int t) -> void
 {
     if (! _imp->eliminations.contains(pair{p, t})) {
-        *_imp->proof_stream << "# 0\n";
-        *_imp->proof_stream << "u 1 ~x" << _imp->variable_mappings[pair{p, t}] << " >= 1 ;\n";
+        *_imp->proof_stream << "setlvl 0;\n";
+        *_imp->proof_stream << "rup 1 ~x" << _imp->variable_mappings[pair{p, t}] << " >= 1 ;\n";
         _imp->eliminations[pair{p, t}] = ++_imp->proof_line;
-        *_imp->proof_stream << "# " << _imp->active_level << '\n';
+        *_imp->proof_stream << "setlvl " << _imp->active_level << ";\n";
     }
 }
 
@@ -334,7 +335,7 @@ auto Proof::incompatible_by_degrees(
     const NamedVertex & t,
     const vector<int> & n_t) -> void
 {
-    *_imp->proof_stream << "* cannot map " << p.second << " to " << t.second << " due to degrees in graph pairs " << g << '\n';
+    *_imp->proof_stream << "% cannot map " << p.second << " to " << t.second << " due to degrees in graph pairs " << g << '\n';
 
     if (_imp->recover_encoding) {
         for (auto & n : n_p)
@@ -343,7 +344,7 @@ auto Proof::incompatible_by_degrees(
             recover_injectivity_constraint(n);
     }
 
-    *_imp->proof_stream << "p";
+    *_imp->proof_stream << "pol";
     bool first = true;
     for (auto & n : n_p) {
         // due to loops or labels, it might not be possible to map n to t.first
@@ -361,14 +362,14 @@ auto Proof::incompatible_by_degrees(
     for (auto & n : n_t)
         *_imp->proof_stream << " " << get<1>(_imp->injectivity_constraints[n]) << " +";
 
-    *_imp->proof_stream << " s 0\n";
+    *_imp->proof_stream << " s ;\n";
     ++_imp->proof_line;
 
-    *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " >= 1 ; " << _imp->proof_line << '\n';
+    *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " >= 1 : " << _imp->proof_line << " ;\n";
     ++_imp->proof_line;
     _imp->eliminations.emplace(pair{p.first, t.first}, _imp->proof_line);
 
-    *_imp->proof_stream << "d " << _imp->proof_line - 1 << " 0\n";
+    *_imp->proof_stream << "del id " << _imp->proof_line - 1 << " ;\n";
 }
 
 auto Proof::incompatible_by_nds(
@@ -379,7 +380,7 @@ auto Proof::incompatible_by_nds(
     const vector<int> & t_subsequence,
     const vector<int> & t_remaining) -> void
 {
-    *_imp->proof_stream << "* cannot map " << p.second << " to " << t.second << " due to nds in graph pairs " << g << '\n';
+    *_imp->proof_stream << "% cannot map " << p.second << " to " << t.second << " due to nds in graph pairs " << g << '\n';
 
     if (_imp->recover_encoding) {
         for (auto & n : p_subsequence)
@@ -396,7 +397,7 @@ auto Proof::incompatible_by_nds(
         need_elimination(n, t_subsequence.back());
 
     // summing up horizontally
-    *_imp->proof_stream << "p";
+    *_imp->proof_stream << "pol";
     bool first = true;
     for (auto & n : p_subsequence) {
         // due to loops or labels, it might not be possible to map n to t.first
@@ -430,13 +431,13 @@ auto Proof::incompatible_by_nds(
         *_imp->proof_stream << " " << _imp->eliminations[pair{n, t_subsequence.back()}] << " +";
     }
 
-    *_imp->proof_stream << " s 0\n";
+    *_imp->proof_stream << " s ;\n";
     ++_imp->proof_line;
 
-    *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " >= 1 ; " << _imp->proof_line << '\n';
+    *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " >= 1 : " << _imp->proof_line << " ;\n";
     ++_imp->proof_line;
 
-    *_imp->proof_stream << "d " << _imp->proof_line - 1 << " 0\n";
+    *_imp->proof_stream << "del id " << _imp->proof_line - 1 << " ;\n";
 }
 
 auto Proof::incompatible_by_loops(
@@ -444,20 +445,20 @@ auto Proof::incompatible_by_loops(
     const NamedVertex & t) -> void
 {
     if (_imp->recover_encoding) {
-        *_imp->proof_stream << "* cannot map " << p.second << " to " << t.second << " due to loop\n";
-        *_imp->proof_stream << "u 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " >= 1 ;\n";
+        *_imp->proof_stream << "% cannot map " << p.second << " to " << t.second << " due to loop\n";
+        *_imp->proof_stream << "rup 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " >= 1 ;\n";
         ++_imp->proof_line;
     }
 }
 
 auto Proof::initial_domain_is_empty(int p, const string & where) -> void
 {
-    *_imp->proof_stream << "* failure due to domain " << p << " being empty at " << where << '\n';
+    *_imp->proof_stream << "% failure due to domain " << p << " being empty at " << where << '\n';
 }
 
 auto Proof::emit_hall_set_or_violator(const vector<NamedVertex> & lhs, const vector<NamedVertex> & rhs) -> void
 {
-    *_imp->proof_stream << "* hall set or violator {";
+    *_imp->proof_stream << "% hall set or violator {";
     for (auto & l : lhs)
         *_imp->proof_stream << " " << l.second;
     *_imp->proof_stream << " } / {";
@@ -472,7 +473,7 @@ auto Proof::emit_hall_set_or_violator(const vector<NamedVertex> & lhs, const vec
             recover_at_least_one_constraint(l.first);
     }
 
-    *_imp->proof_stream << "p";
+    *_imp->proof_stream << "pol";
     bool first = true;
     for (auto & l : lhs) {
         if (first) {
@@ -484,24 +485,24 @@ auto Proof::emit_hall_set_or_violator(const vector<NamedVertex> & lhs, const vec
     }
     for (auto & r : rhs)
         *_imp->proof_stream << " " << get<1>(_imp->injectivity_constraints[r.first]) << " +";
-    *_imp->proof_stream << " 0\n";
+    *_imp->proof_stream << " ;\n";
     ++_imp->proof_line;
 }
 
 auto Proof::root_propagation_failed() -> void
 {
-    *_imp->proof_stream << "* root node propagation failed\n";
+    *_imp->proof_stream << "% root node propagation failed\n";
 }
 
 auto Proof::guessing(int depth, const NamedVertex & branch_v, const NamedVertex & val) -> void
 {
-    *_imp->proof_stream << "* [" << depth << "] guessing " << branch_v.second << "=" << val.second << '\n';
+    *_imp->proof_stream << "% [" << depth << "] guessing " << branch_v.second << "=" << val.second << '\n';
 }
 
 auto Proof::propagation_failure(const vector<pair<int, int>> & decisions, const NamedVertex & branch_v, const NamedVertex & val) -> void
 {
-    *_imp->proof_stream << "* [" << decisions.size() << "] propagation failure on " << branch_v.second << "=" << val.second << '\n';
-    *_imp->proof_stream << "u ";
+    *_imp->proof_stream << "% [" << decisions.size() << "] propagation failure on " << branch_v.second << "=" << val.second << '\n';
+    *_imp->proof_stream << "rup ";
     for (auto & [var, val] : decisions)
         *_imp->proof_stream << " 1 ~x" << _imp->variable_mappings[pair{var, val}];
     *_imp->proof_stream << " >= 1 ;\n";
@@ -511,11 +512,11 @@ auto Proof::propagation_failure(const vector<pair<int, int>> & decisions, const 
 auto Proof::incorrect_guess(const vector<pair<int, int>> & decisions, bool failure) -> void
 {
     if (failure)
-        *_imp->proof_stream << "* [" << decisions.size() << "] incorrect guess\n";
+        *_imp->proof_stream << "% [" << decisions.size() << "] incorrect guess\n";
     else
-        *_imp->proof_stream << "* [" << decisions.size() << "] backtracking\n";
+        *_imp->proof_stream << "% [" << decisions.size() << "] backtracking\n";
 
-    *_imp->proof_stream << "u";
+    *_imp->proof_stream << "rup";
     for (auto & [var, val] : decisions)
         *_imp->proof_stream << " 1 ~x" << _imp->variable_mappings[pair{var, val}];
     *_imp->proof_stream << " >= 1 ;\n";
@@ -528,19 +529,19 @@ auto Proof::out_of_guesses(const vector<pair<int, int>> &) -> void
 
 auto Proof::unit_propagating(const NamedVertex & var, const NamedVertex & val) -> void
 {
-    *_imp->proof_stream << "* unit propagating " << var.second << "=" << val.second << '\n';
+    *_imp->proof_stream << "% unit propagating " << var.second << "=" << val.second << '\n';
 }
 
 auto Proof::start_level(int l) -> void
 {
-    *_imp->proof_stream << "# " << l << '\n';
+    *_imp->proof_stream << "setlvl " << l << ";\n";
     _imp->largest_level_set = max(_imp->largest_level_set, l);
     _imp->active_level = l;
 }
 
 auto Proof::back_up_to_level(int l) -> void
 {
-    *_imp->proof_stream << "# " << l << '\n';
+    *_imp->proof_stream << "setlvl " << l << ";\n";
     _imp->largest_level_set = max(_imp->largest_level_set, l);
     _imp->active_level = l;
 }
@@ -548,19 +549,19 @@ auto Proof::back_up_to_level(int l) -> void
 auto Proof::forget_level(int l) -> void
 {
     if (_imp->largest_level_set >= l)
-        *_imp->proof_stream << "w " << l << '\n';
+        *_imp->proof_stream << "wiplvl " << l << ";\n";
 }
 
 auto Proof::back_up_to_top() -> void
 {
-    *_imp->proof_stream << "# " << 0 << '\n';
+    *_imp->proof_stream << "setlvl " << 0 << ";\n";
     _imp->active_level = 0;
 }
 
 auto Proof::post_restart_nogood(const vector<pair<int, int>> & decisions) -> void
 {
-    *_imp->proof_stream << "* [" << decisions.size() << "] restart nogood\n";
-    *_imp->proof_stream << "u";
+    *_imp->proof_stream << "% [" << decisions.size() << "] restart nogood\n";
+    *_imp->proof_stream << "rup";
     for (auto & [var, val] : decisions)
         *_imp->proof_stream << " 1 ~x" << _imp->variable_mappings[pair{var, val}];
     *_imp->proof_stream << " >= 1 ;\n";
@@ -569,15 +570,15 @@ auto Proof::post_restart_nogood(const vector<pair<int, int>> & decisions) -> voi
 
 auto Proof::post_solution(const vector<pair<NamedVertex, NamedVertex>> & decisions) -> void
 {
-    *_imp->proof_stream << "* found solution";
+    *_imp->proof_stream << "% found solution";
     for (auto & [var, val] : decisions)
         *_imp->proof_stream << " " << var.second << "=" << val.second;
-    *_imp->proof_stream << '\n';
+    *_imp->proof_stream << ";\n";
 
     *_imp->proof_stream << "solx";
     for (auto & [var, val] : decisions)
         *_imp->proof_stream << " x" << _imp->variable_mappings[pair{var.first, val.first}];
-    *_imp->proof_stream << '\n';
+    *_imp->proof_stream << ";\n";
     ++_imp->proof_line;
 }
 
@@ -598,7 +599,7 @@ auto Proof::new_incumbent(const vector<pair<int, bool>> & solution) -> void
     for (auto & [v, w] : _imp->zero_in_proof_objectives)
         *_imp->proof_stream << " ~"
                             << "x" << _imp->variable_mappings[pair{v, w}];
-    *_imp->proof_stream << '\n';
+    *_imp->proof_stream << ";\n";
     _imp->objective_line = ++_imp->proof_line;
 }
 
@@ -627,7 +628,7 @@ auto Proof::create_exact_path_graphs(
     for (auto & u : d_n_t)
         if (u != t)
             tidied_up << " 1 x" << _imp->variable_mappings[pair{q.first, u.first}];
-    tidied_up << " >= 1 ;";
+    tidied_up << " >= 1 :";
 
     auto it = _imp->cached_proof_lines.find(tidied_up.str());
     if (it != _imp->cached_proof_lines.end()) {
@@ -635,7 +636,7 @@ auto Proof::create_exact_path_graphs(
         return;
     }
 
-    *_imp->proof_stream << "* adjacency " << p.second << " maps to " << t.second << " in G^[" << g << "x2] so " << q.second << " maps to one of...\n";
+    *_imp->proof_stream << "% adjacency " << p.second << " maps to " << t.second << " in G^[" << g << "x2] so " << q.second << " maps to one of...\n";
 
     if (_imp->recover_encoding) {
         recover_injectivity_constraint(t.first);
@@ -661,8 +662,8 @@ auto Proof::create_exact_path_graphs(
         }
     }
 
-    *_imp->proof_stream << "# 1\n";
-    *_imp->proof_stream << "p";
+    *_imp->proof_stream << "setlvl 1;\n";
+    *_imp->proof_stream << "pol";
 
     // if p maps to t then things in between_p_and_q have to go to one of these...
     bool first = true;
@@ -683,18 +684,18 @@ auto Proof::create_exact_path_graphs(
         }
     }
 
-    *_imp->proof_stream << " s 0\n";
+    *_imp->proof_stream << " s ;\n";
     ++_imp->proof_line;
 
     // first tidy-up step: if p maps to t then q maps to something a two-walk away from t
     *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}];
     for (auto & u : two_away_from_t)
         *_imp->proof_stream << " 1 x" << _imp->variable_mappings[pair{q.first, u.first.first}];
-    *_imp->proof_stream << " >= 1 ; " << _imp->proof_line << '\n';
+    *_imp->proof_stream << " >= 1 : " << _imp->proof_line << " ;\n";
     ++_imp->proof_line;
 
     // if p maps to t then q does not map to t
-    *_imp->proof_stream << "p " << _imp->proof_line << " " << get<1>(_imp->injectivity_constraints[t.first]) << " + s 0\n";
+    *_imp->proof_stream << "pol  " << _imp->proof_line << " " << get<1>(_imp->injectivity_constraints[t.first]) << " + s ;\n";
     ++_imp->proof_line;
 
     // and cancel out stray extras from injectivity
@@ -702,7 +703,7 @@ auto Proof::create_exact_path_graphs(
     for (auto & u : two_away_from_t)
         if (u.first != t)
             *_imp->proof_stream << " 1 x" << _imp->variable_mappings[pair{q.first, u.first.first}];
-    *_imp->proof_stream << " >= 1 ; " << _imp->proof_line << '\n';
+    *_imp->proof_stream << " >= 1 : " << _imp->proof_line << " ;\n";
     ++_imp->proof_line;
 
     vector<long> things_to_add_up;
@@ -713,7 +714,7 @@ auto Proof::create_exact_path_graphs(
         if ((u.first == t) || (d_n_t.end() != find(d_n_t.begin(), d_n_t.end(), u.first)))
             continue;
 
-        *_imp->proof_stream << "p";
+        *_imp->proof_stream << "pol";
         bool first = true;
         for (auto & b : between_p_and_q) {
             *_imp->proof_stream << " " << get<1>(_imp->adjacency_lines[tuple{0, p.first, b.first, t.first}]);
@@ -727,36 +728,36 @@ auto Proof::create_exact_path_graphs(
         for (auto & z : u.second)
             *_imp->proof_stream << " " << get<1>(_imp->injectivity_constraints[z.first]) << " +";
 
-        *_imp->proof_stream << " s 0\n";
+        *_imp->proof_stream << " s ;\n";
         ++_imp->proof_line;
 
         // want: ~x_p_t + ~x_q_u >= 1
         *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}]
-                            << " 1 ~x" << _imp->variable_mappings[pair{q.first, u.first.first}] << " >= 1 ; "
-                            << _imp->proof_line << '\n';
+                            << " 1 ~x" << _imp->variable_mappings[pair{q.first, u.first.first}] << " >= 1 : "
+                            << _imp->proof_line << " ;\n";
         things_to_add_up.push_back(++_imp->proof_line);
     }
 
     // do the getting rid of
     if (things_to_add_up.size() > 1) {
         bool first = true;
-        *_imp->proof_stream << "p";
+        *_imp->proof_stream << "pol";
         for (auto & t : things_to_add_up) {
             *_imp->proof_stream << " " << t;
             if (! first)
                 *_imp->proof_stream << " +";
             first = false;
         }
-        *_imp->proof_stream << " s 0\n";
+        *_imp->proof_stream << " s ;\n";
         ++_imp->proof_line;
     }
 
-    *_imp->proof_stream << "# 0\n";
-    *_imp->proof_stream << "ia " << tidied_up.str() << " " << _imp->proof_line << '\n';
+    *_imp->proof_stream << "setlvl 0;\n";
+    *_imp->proof_stream << "ia " << tidied_up.str() << " " << _imp->proof_line << " ;\n";
     ++_imp->proof_line;
     _imp->adjacency_lines.emplace(tuple{g, p.first, q.first, t.first}, tuple{_imp->proof_line, _imp->proof_line, ""});
     _imp->cached_proof_lines.emplace(tidied_up.str(), _imp->proof_line);
-    *_imp->proof_stream << "w 1\n";
+    *_imp->proof_stream << "wiplvl 1;\n";
 }
 
 auto Proof::hack_in_shape_graph(
@@ -766,7 +767,7 @@ auto Proof::hack_in_shape_graph(
     const NamedVertex & t,
     const std::vector<NamedVertex> & n_t) -> void
 {
-    *_imp->proof_stream << "* adjacency " << p.second << " maps to " << t.second << " in shape graph " << g << " so " << q.second << " maps to one of...\n";
+    *_imp->proof_stream << "% adjacency " << p.second << " maps to " << t.second << " in shape graph " << g << " so " << q.second << " maps to one of...\n";
     *_imp->proof_stream << "a 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}];
     for (auto & u : n_t)
         *_imp->proof_stream << " 1 x" << _imp->variable_mappings[pair{q.first, u.first}];
@@ -783,7 +784,7 @@ auto Proof::create_distance3_graphs_but_actually_distance_1(
     const NamedVertex & t,
     const vector<NamedVertex> & d3_from_t) -> void
 {
-    *_imp->proof_stream << "* adjacency " << p.second << " maps to " << t.second << " in G^3 so by adjacency, " << q.second << " maps to one of...\n";
+    *_imp->proof_stream << "% adjacency " << p.second << " maps to " << t.second << " in G^3 so by adjacency, " << q.second << " maps to one of...\n";
 
     if (_imp->recover_encoding)
         recover_adjacency_lines(0, p.first, q.first, t.first);
@@ -791,7 +792,7 @@ auto Proof::create_distance3_graphs_but_actually_distance_1(
     *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}];
     for (auto & u : d3_from_t)
         *_imp->proof_stream << " 1 x" << _imp->variable_mappings[pair{q.first, u.first}];
-    *_imp->proof_stream << " >= 1 ; " << get<1>(_imp->adjacency_lines[tuple{0, p.first, q.first, t.first}]) << '\n';
+    *_imp->proof_stream << " >= 1 : " << get<1>(_imp->adjacency_lines[tuple{0, p.first, q.first, t.first}]) << " ;\n";
     ++_imp->proof_line;
 
     _imp->adjacency_lines.emplace(tuple{g, p.first, q.first, t.first}, tuple{_imp->proof_line, _imp->proof_line, ""});
@@ -807,7 +808,7 @@ auto Proof::create_distance3_graphs_but_actually_distance_2(
     const vector<NamedVertex> & d2_from_t,
     const vector<NamedVertex> & d3_from_t) -> void
 {
-    *_imp->proof_stream << "* adjacency " << p.second << " maps to " << t.second << " in G^3 so using vertex " << path_from_p_to_q.second << ", " << q.second << " maps to one of...\n";
+    *_imp->proof_stream << "% adjacency " << p.second << " maps to " << t.second << " in G^3 so using vertex " << path_from_p_to_q.second << ", " << q.second << " maps to one of...\n";
 
     if (_imp->recover_encoding) {
         recover_adjacency_lines(0, p.first, path_from_p_to_q.first, t.first);
@@ -815,9 +816,9 @@ auto Proof::create_distance3_graphs_but_actually_distance_2(
             recover_adjacency_lines(0, path_from_p_to_q.first, q.first, u.first);
     }
 
-    *_imp->proof_stream << "# 1\n";
+    *_imp->proof_stream << "setlvl 1;\n";
 
-    *_imp->proof_stream << "p";
+    *_imp->proof_stream << "pol";
 
     // if p maps to t then the first thing on the path from p to q has to go to one of...
     *_imp->proof_stream << " " << get<1>(_imp->adjacency_lines[tuple{0, p.first, path_from_p_to_q.first, t.first}]);
@@ -825,22 +826,22 @@ auto Proof::create_distance3_graphs_but_actually_distance_2(
     for (auto & u : d1_from_t)
         *_imp->proof_stream << " " << get<1>(_imp->adjacency_lines[tuple{0, path_from_p_to_q.first, q.first, u.first}]) << " +";
 
-    *_imp->proof_stream << " 0\n";
+    *_imp->proof_stream << " ;\n";
     ++_imp->proof_line;
 
     // tidy up
     *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}];
     for (auto & u : d2_from_t)
         *_imp->proof_stream << " 1 x" << _imp->variable_mappings[pair{q.first, u.first}];
-    *_imp->proof_stream << " >= 1 ; " << _imp->proof_line << '\n';
+    *_imp->proof_stream << " >= 1 : " << _imp->proof_line << " ;\n";
     ++_imp->proof_line;
 
-    *_imp->proof_stream << "# 0\n";
+    *_imp->proof_stream << "setlvl 0;\n";
 
     *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}];
     for (auto & u : d3_from_t)
         *_imp->proof_stream << " 1 x" << _imp->variable_mappings[pair{q.first, u.first}];
-    *_imp->proof_stream << " >= 1 ; " << _imp->proof_line << '\n';
+    *_imp->proof_stream << " >= 1 : " << _imp->proof_line << " ;\n";
     ++_imp->proof_line;
 
     _imp->adjacency_lines.emplace(tuple{g, p.first, q.first, t.first}, tuple{_imp->proof_line, _imp->proof_line, ""});
@@ -857,7 +858,7 @@ auto Proof::create_distance3_graphs(
     const vector<NamedVertex> & d2_from_t,
     const vector<NamedVertex> & d3_from_t) -> void
 {
-    *_imp->proof_stream << "* adjacency " << p.second << " maps to " << t.second << " in G^3 so using path " << path_from_p_to_q_1.second << " -- " << path_from_p_to_q_2.second << ", " << q.second << " maps to one of...\n";
+    *_imp->proof_stream << "% adjacency " << p.second << " maps to " << t.second << " in G^3 so using path " << path_from_p_to_q_1.second << " -- " << path_from_p_to_q_2.second << ", " << q.second << " maps to one of...\n";
 
     if (_imp->recover_encoding) {
         recover_adjacency_lines(0, p.first, path_from_p_to_q_1.first, t.first);
@@ -867,9 +868,9 @@ auto Proof::create_distance3_graphs(
             recover_adjacency_lines(0, path_from_p_to_q_2.first, q.first, u.first);
     }
 
-    *_imp->proof_stream << "# 1\n";
+    *_imp->proof_stream << "setlvl 1;\n";
 
-    *_imp->proof_stream << "p";
+    *_imp->proof_stream << "pol";
 
     // if p maps to t then the first thing on the path from p to q has to go to one of...
     *_imp->proof_stream << " " << get<1>(_imp->adjacency_lines[tuple{0, p.first, path_from_p_to_q_1.first, t.first}]);
@@ -877,28 +878,28 @@ auto Proof::create_distance3_graphs(
     for (auto & u : d1_from_t)
         *_imp->proof_stream << " " << get<1>(_imp->adjacency_lines[tuple{0, path_from_p_to_q_1.first, path_from_p_to_q_2.first, u.first}]) << " +";
 
-    *_imp->proof_stream << " 0\n";
+    *_imp->proof_stream << " ;\n";
     ++_imp->proof_line;
 
     // tidy up
     *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}];
     for (auto & u : d2_from_t)
         *_imp->proof_stream << " 1 x" << _imp->variable_mappings[pair{path_from_p_to_q_2.first, u.first}];
-    *_imp->proof_stream << " >= 1 ; " << _imp->proof_line << '\n';
+    *_imp->proof_stream << " >= 1 : " << _imp->proof_line << " ;\n";
     ++_imp->proof_line;
 
-    *_imp->proof_stream << "p " << _imp->proof_line;
+    *_imp->proof_stream << "pol  " << _imp->proof_line;
     for (auto & u : d2_from_t)
         *_imp->proof_stream << " " << get<1>(_imp->adjacency_lines[tuple{0, path_from_p_to_q_2.first, q.first, u.first}]) << " s +";
-    *_imp->proof_stream << " 0\n";
+    *_imp->proof_stream << " ;\n";
     ++_imp->proof_line;
 
-    *_imp->proof_stream << "# 0\n";
+    *_imp->proof_stream << "setlvl 0;\n";
 
     *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}];
     for (auto & u : d3_from_t)
         *_imp->proof_stream << " 1 x" << _imp->variable_mappings[pair{q.first, u.first}];
-    *_imp->proof_stream << " >= 1 ; " << _imp->proof_line << '\n';
+    *_imp->proof_stream << " >= 1 : " << _imp->proof_line << " ;\n";
     ++_imp->proof_line;
 
     _imp->adjacency_lines.emplace(tuple{g, p.first, q.first, t.first}, tuple{_imp->proof_line, _imp->proof_line, ""});
@@ -913,7 +914,7 @@ auto Proof::create_binary_variable(int vertex,
 auto Proof::create_objective(int n, optional<int> d) -> void
 {
     if (d) {
-        _imp->model_stream << "* objective\n";
+        _imp->model_stream << "% objective\n";
         for (int v = 0; v < n; ++v)
             _imp->model_stream << "1 x" << _imp->binary_variable_mappings[v] << " ";
         _imp->model_stream << ">= " << *d << ";\n";
@@ -944,7 +945,7 @@ auto Proof::create_non_edge_constraint(int p, int q) -> void
 auto Proof::create_null_decision_bound(int p, int t, optional<int> d) -> void
 {
     if (d) {
-        _imp->model_stream << "* objective\n";
+        _imp->model_stream << "% objective\n";
         for (int v = 0; v < p; ++v)
             _imp->model_stream << " 1 x" << _imp->variable_mappings[pair{v, t}] << " ";
         _imp->model_stream << ">= " << *d << " ;\n";
@@ -964,18 +965,18 @@ auto Proof::create_null_decision_bound(int p, int t, optional<int> d) -> void
 auto Proof::backtrack_from_binary_variables(const vector<int> & v) -> void
 {
     if (! _imp->doing_hom_colour_proof) {
-        *_imp->proof_stream << "u";
+        *_imp->proof_stream << "rup";
         for (auto & w : v)
             *_imp->proof_stream << " 1 ~x" << _imp->binary_variable_mappings[w];
         *_imp->proof_stream << " >= 1 ;\n";
         ++_imp->proof_line;
     }
     else {
-        *_imp->proof_stream << "* backtrack shenanigans, depth " << v.size() << '\n';
+        *_imp->proof_stream << "% backtrack shenanigans, depth " << v.size() << '\n';
         function<auto(unsigned, const vector<pair<int, int>> &)->void> f;
         f = [&](unsigned d, const vector<pair<int, int>> & trail) -> void {
             if (d == v.size()) {
-                *_imp->proof_stream << "u 1 ~x" << _imp->variable_mappings[pair{_imp->hom_colour_proof_p.first, _imp->hom_colour_proof_t.first}];
+                *_imp->proof_stream << "rup 1 ~x" << _imp->variable_mappings[pair{_imp->hom_colour_proof_p.first, _imp->hom_colour_proof_t.first}];
                 for (auto & t : trail)
                     *_imp->proof_stream << " 1 ~x" << _imp->variable_mappings[t];
                 *_imp->proof_stream << " >= 1 ;\n";
@@ -995,7 +996,7 @@ auto Proof::backtrack_from_binary_variables(const vector<int> & v) -> void
 
 auto Proof::colour_bound(const vector<vector<int>> & ccs) -> void
 {
-    *_imp->proof_stream << "* bound, ccs";
+    *_imp->proof_stream << "% bound, ccs";
     for (auto & cc : ccs) {
         *_imp->proof_stream << " [";
         for (auto & c : cc)
@@ -1012,13 +1013,13 @@ auto Proof::colour_bound(const vector<vector<int>> & ccs) -> void
             for (unsigned i = 0 ; i < cc.size() ; ++i)
                 for (unsigned j = i + 1 ; j < cc.size() ; ++j)
                     if (! _imp->non_edge_constraints.contains(pair{cc[i], cc[j]})) {
-                        *_imp->proof_stream << "# 0\n";
+                        *_imp->proof_stream << "setlvl 0;\n";
                         *_imp->proof_stream << "ea -1 x" << _imp->binary_variable_mappings[cc[i]]
                             << " -1 x" << _imp->binary_variable_mappings[cc[j]] << " >= -1 ;\n";
                         auto n = ++_imp->proof_line;
                         _imp->non_edge_constraints[{cc[i], cc[j]}] = n;
                         _imp->non_edge_constraints[{cc[j], cc[i]}] = n;
-                        *_imp->proof_stream << "# " << _imp->active_level << '\n';
+                        *_imp->proof_stream << "setlvl " << _imp->active_level << ";\n";
                     }
         }
     }
@@ -1026,7 +1027,7 @@ auto Proof::colour_bound(const vector<vector<int>> & ccs) -> void
     vector<long> to_sum;
     auto do_one_cc = [&](const auto & cc, const auto & non_edge_constraint) {
         if (cc.size() > 2) {
-            *_imp->proof_stream << "p " << non_edge_constraint(cc[0], cc[1]);
+            *_imp->proof_stream << "pol  " << non_edge_constraint(cc[0], cc[1]);
 
             for (unsigned i = 2; i < cc.size(); ++i) {
                 *_imp->proof_stream << " " << i << " *";
@@ -1053,7 +1054,7 @@ auto Proof::colour_bound(const vector<vector<int>> & ccs) -> void
                 for (auto & v : _imp->p_clique)
                     bigger_cc.push_back(pair{v, _imp->t_clique_neighbourhood.find(c)->second});
 
-            *_imp->proof_stream << "* colour class [";
+            *_imp->proof_stream << "% colour class [";
             for (auto & c : bigger_cc)
                 *_imp->proof_stream << " " << c.first.second << "/" << c.second.second;
             *_imp->proof_stream << " ]\n";
@@ -1065,7 +1066,7 @@ auto Proof::colour_bound(const vector<vector<int>> & ccs) -> void
         else
             do_one_cc(cc, [&](int a, int b) -> long { return _imp->non_edge_constraints[pair{a, b}]; });
 
-        *_imp->proof_stream << "p " << _imp->objective_line;
+        *_imp->proof_stream << "pol  " << _imp->objective_line;
 
         if (_imp->doing_mcs_by_clique) {
             for (auto & [_, v] : _imp->at_least_one_value_constraints) {
@@ -1082,8 +1083,8 @@ auto Proof::colour_bound(const vector<vector<int>> & ccs) -> void
 
 auto Proof::prepare_hom_clique_proof(const NamedVertex & p, const NamedVertex & t, unsigned size) -> void
 {
-    *_imp->proof_stream << "* clique of size " << size << " around neighbourhood of " << p.second << " but not " << t.second << '\n';
-    *_imp->proof_stream << "# 1\n";
+    *_imp->proof_stream << "% clique of size " << size << " around neighbourhood of " << p.second << " but not " << t.second << '\n';
+    *_imp->proof_stream << "setlvl 1;\n";
     _imp->doing_hom_colour_proof = true;
     _imp->hom_colour_proof_p = p;
     _imp->hom_colour_proof_t = t;
@@ -1094,17 +1095,17 @@ auto Proof::start_hom_clique_proof(const NamedVertex & p, vector<NamedVertex> &&
     _imp->p_clique = move(p_clique);
     _imp->t_clique_neighbourhood = move(t_clique_neighbourhood);
 
-    *_imp->proof_stream << "* hom clique objective\n";
+    *_imp->proof_stream << "% hom clique objective\n";
     vector<long> to_sum;
     for (auto & q : _imp->p_clique) {
-        *_imp->proof_stream << "u 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}];
+        *_imp->proof_stream << "rup 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}];
         for (auto & u : _imp->t_clique_neighbourhood)
             *_imp->proof_stream << " 1 x" << _imp->variable_mappings[pair{q.first, u.second.first}];
         *_imp->proof_stream << " >= 1 ;\n";
         to_sum.push_back(++_imp->proof_line);
     }
 
-    *_imp->proof_stream << "p";
+    *_imp->proof_stream << "pol";
     bool first = true;
     for (auto & t : to_sum) {
         *_imp->proof_stream << " " << t;
@@ -1115,26 +1116,26 @@ auto Proof::start_hom_clique_proof(const NamedVertex & p, vector<NamedVertex> &&
     *_imp->proof_stream << '\n';
     _imp->objective_line = ++_imp->proof_line;
 
-    *_imp->proof_stream << "* hom clique non edges for injectivity\n";
+    *_imp->proof_stream << "% hom clique non edges for injectivity\n";
 
     for (auto & p : _imp->p_clique)
         for (auto & q : _imp->p_clique)
             if (p != q) {
                 for (auto & [_, t] : _imp->t_clique_neighbourhood) {
-                    *_imp->proof_stream << "u 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " 1 ~x" << _imp->variable_mappings[pair{q.first, t.first}] << " >= 1 ;\n";
+                    *_imp->proof_stream << "rup 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " 1 ~x" << _imp->variable_mappings[pair{q.first, t.first}] << " >= 1 ;\n";
                     ++_imp->proof_line;
                     _imp->clique_for_hom_non_edge_constraints.emplace(pair{pair{p, t}, pair{q, t}}, _imp->proof_line);
                     _imp->clique_for_hom_non_edge_constraints.emplace(pair{pair{q, t}, pair{p, t}}, _imp->proof_line);
                 }
             }
 
-    *_imp->proof_stream << "* hom clique non edges for variables\n";
+    *_imp->proof_stream << "% hom clique non edges for variables\n";
 
     for (auto & p : _imp->p_clique)
         for (auto & [_, t] : _imp->t_clique_neighbourhood) {
             for (auto & [_, u] : _imp->t_clique_neighbourhood) {
                 if (t != u) {
-                    *_imp->proof_stream << "u 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " 1 ~x" << _imp->variable_mappings[pair{p.first, u.first}] << " >= 1 ;\n";
+                    *_imp->proof_stream << "rup 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " 1 ~x" << _imp->variable_mappings[pair{p.first, u.first}] << " >= 1 ;\n";
                     ++_imp->proof_line;
                     _imp->clique_for_hom_non_edge_constraints.emplace(pair{pair{p, t}, pair{p, u}}, _imp->proof_line);
                     _imp->clique_for_hom_non_edge_constraints.emplace(pair{pair{p, u}, pair{p, t}}, _imp->proof_line);
@@ -1145,10 +1146,10 @@ auto Proof::start_hom_clique_proof(const NamedVertex & p, vector<NamedVertex> &&
 
 auto Proof::finish_hom_clique_proof(const NamedVertex & p, const NamedVertex & t, unsigned size) -> void
 {
-    *_imp->proof_stream << "* end clique of size " << size << " around neighbourhood of " << p.second << " but not " << t.second << '\n';
-    *_imp->proof_stream << "# 0\n";
-    *_imp->proof_stream << "u 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " >= 1 ;\n";
-    *_imp->proof_stream << "w 1\n";
+    *_imp->proof_stream << "% end clique of size " << size << " around neighbourhood of " << p.second << " but not " << t.second << '\n';
+    *_imp->proof_stream << "setlvl 0;\n";
+    *_imp->proof_stream << "rup 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " >= 1 ;\n";
+    *_imp->proof_stream << "wiplvl 1;\n";
     ++_imp->proof_line;
     _imp->doing_hom_colour_proof = false;
     _imp->clique_for_hom_non_edge_constraints.clear();
@@ -1161,11 +1162,11 @@ auto Proof::add_hom_clique_non_edge(
     const NamedVertex & t,
     const NamedVertex & u) -> void
 {
-    *_imp->proof_stream << "* hom clique non edges for " << t.second << " " << u.second << '\n';
+    *_imp->proof_stream << "% hom clique non edges for " << t.second << " " << u.second << '\n';
     for (auto & p : p_clique) {
         for (auto & q : p_clique) {
             if (p != q) {
-                *_imp->proof_stream << "u 1 ~x" << _imp->variable_mappings[pair{pp.first, tt.first}]
+                *_imp->proof_stream << "rup 1 ~x" << _imp->variable_mappings[pair{pp.first, tt.first}]
                                     << " 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}]
                                     << " 1 ~x" << _imp->variable_mappings[pair{q.first, u.first}] << " >= 1 ;\n";
                 ++_imp->proof_line;
@@ -1179,7 +1180,7 @@ auto Proof::add_hom_clique_non_edge(
 auto Proof::mcs_bound(
     const vector<pair<set<int>, set<int>>> & partitions) -> void
 {
-    *_imp->proof_stream << "* failed bound\n";
+    *_imp->proof_stream << "% failed bound\n";
 
     if (_imp->recover_encoding) {
         for (auto & [l, r] : partitions) {
@@ -1195,7 +1196,7 @@ auto Proof::mcs_bound(
         if (r.size() >= l.size())
             continue;
 
-        *_imp->proof_stream << "p";
+        *_imp->proof_stream << "pol";
         bool first = true;
         for (auto & v : l) {
             *_imp->proof_stream << " " << get<1>(_imp->at_least_one_value_constraints[v]);
@@ -1212,7 +1213,7 @@ auto Proof::mcs_bound(
     }
 
     if (! to_sum.empty()) {
-        *_imp->proof_stream << "p " << _imp->objective_line;
+        *_imp->proof_stream << "pol  " << _imp->objective_line;
         for (auto & t : to_sum)
             *_imp->proof_stream << " " << t << " +";
         *_imp->proof_stream << '\n';
@@ -1223,8 +1224,8 @@ auto Proof::mcs_bound(
 auto Proof::rewrite_mcs_objective(int pattern_size) -> void
 {
     if (! _imp->recover_encoding) {
-        *_imp->proof_stream << "* get the objective function to talk about nulls, not non-nulls\n";
-        *_imp->proof_stream << "p " << _imp->objective_line;
+        *_imp->proof_stream << "% get the objective function to talk about nulls, not non-nulls\n";
+        *_imp->proof_stream << "pol  " << _imp->objective_line;
         for (int v = 0; v < pattern_size; ++v)
             *_imp->proof_stream << " " << get<1>(_imp->at_most_one_value_constraints[v]) << " +";
         *_imp->proof_stream << '\n';
@@ -1234,7 +1235,7 @@ auto Proof::rewrite_mcs_objective(int pattern_size) -> void
 
 auto Proof::create_connected_constraints(int p, int t, const function<auto(int, int)->bool> & adj) -> void
 {
-    _imp->model_stream << "* selected vertices must be connected, walk 1\n";
+    _imp->model_stream << "% selected vertices must be connected, walk 1\n";
     int mapped_to_null = t;
     int cnum = _imp->variable_mappings.size();
 
@@ -1262,7 +1263,7 @@ auto Proof::create_connected_constraints(int p, int t, const function<auto(int, 
     int last_k = 0;
     for (int k = 2 ; ; k *= 2) {
         last_k = k;
-        _imp->model_stream << "* selected vertices must be connected, walk " << k << '\n';
+        _imp->model_stream << "% selected vertices must be connected, walk " << k << '\n';
         for (int v = 0; v < p; ++v)
             for (int w = 0; w < v; ++w) {
                 string n = "conn" + to_string(k) + "_" + to_string(v) + "_" + to_string(w);
@@ -1309,7 +1310,7 @@ auto Proof::create_connected_constraints(int p, int t, const function<auto(int, 
             break;
     }
 
-    _imp->model_stream << "* if two vertices are used, they must be connected\n";
+    _imp->model_stream << "% if two vertices are used, they must be connected\n";
     for (int v = 0; v < p; ++v)
         for (int w = 0; w < v; ++w) {
             _imp->model_stream << "1 x" << _imp->variable_mappings[pair{v, mapped_to_null}]
@@ -1324,7 +1325,7 @@ auto Proof::create_connected_constraints(int p, int t, const function<auto(int, 
 
 auto Proof::not_connected_in_underlying_graph(const std::vector<int> & x, int y) -> void
 {
-    *_imp->proof_stream << "u 1 ~x" << _imp->binary_variable_mappings[y];
+    *_imp->proof_stream << "rup 1 ~x" << _imp->binary_variable_mappings[y];
     for (auto & v : x)
         *_imp->proof_stream << " 1 ~x" << _imp->binary_variable_mappings[v];
     *_imp->proof_stream << " >= 1 ;\n";
@@ -1354,7 +1355,7 @@ auto Proof::create_clique_encoding(
 
 auto Proof::create_clique_nonedge(int v, int w) -> void
 {
-    *_imp->proof_stream << "u 1 ~x" << _imp->binary_variable_mappings[v]
+    *_imp->proof_stream << "rup 1 ~x" << _imp->binary_variable_mappings[v]
                         << " 1 ~x" << _imp->binary_variable_mappings[w] << " >= 1 ;\n";
     ++_imp->proof_line;
     _imp->non_edge_constraints.emplace(pair{v, w}, _imp->proof_line);
@@ -1368,9 +1369,9 @@ auto Proof::super_extra_verbose() const -> bool
 
 auto Proof::show_domains(const string & s, const std::vector<std::pair<NamedVertex, std::vector<NamedVertex>>> & domains) -> void
 {
-    *_imp->proof_stream << "* " << s << ", domains follow\n";
+    *_imp->proof_stream << "% " << s << ", domains follow\n";
     for (auto & [p, ts] : domains) {
-        *_imp->proof_stream << "*    " << p.second << " size " << ts.size() << " = {";
+        *_imp->proof_stream << "%    " << p.second << " size " << ts.size() << " = {";
         for (auto & t : ts)
             *_imp->proof_stream << " " << t.second;
         *_imp->proof_stream << " }\n";
@@ -1379,5 +1380,5 @@ auto Proof::show_domains(const string & s, const std::vector<std::pair<NamedVert
 
 auto Proof::propagated(const NamedVertex & p, const NamedVertex & t, int g, int n_values, const NamedVertex & q) -> void
 {
-    *_imp->proof_stream << "* adjacency propagation from " << p.second << " -> " << t.second << " in graph pairs " << g << " deleted " << n_values << " values from " << q.second << '\n';
+    *_imp->proof_stream << "% adjacency propagation from " << p.second << " -> " << t.second << " in graph pairs " << g << " deleted " << n_values << " values from " << q.second << '\n';
 }

--- a/gss/innards/proof.cc
+++ b/gss/innards/proof.cc
@@ -108,7 +108,7 @@ auto Proof::create_cp_variable(int pattern_vertex, int target_size,
     for (int i = 0; i < target_size; ++i)
         _imp->variable_mappings.emplace(pair{pattern_vertex, i}, pattern_name(pattern_vertex) + "_" + target_name(i));
 
-    _imp->model_stream << "* vertex " << pattern_vertex << " domain\n";
+    _imp->model_stream << "% vertex " << pattern_vertex << " domain\n";
     stringstream al1_constraint;
     for (int i = 0; i < target_size; ++i)
         al1_constraint << "1 x" << _imp->variable_mappings[{pattern_vertex, i}] << " ";
@@ -129,7 +129,7 @@ auto Proof::create_cp_variable(int pattern_vertex, int target_size,
 auto Proof::create_injectivity_constraints(int pattern_size, int target_size) -> void
 {
     for (int v = 0; v < target_size; ++v) {
-        _imp->model_stream << "* injectivity on value " << v << '\n';
+        _imp->model_stream << "% injectivity on value " << v << '\n';
         stringstream injectivity_constraint;
 
         for (int p = 0; p < pattern_size; ++p) {
@@ -154,7 +154,7 @@ auto Proof::create_forbidden_assignment_constraint(int p, int t) -> void
 
 auto Proof::start_adjacency_constraints_for(int p, int t) -> void
 {
-    _imp->model_stream << "* adjacency " << p << " maps to " << t << '\n';
+    _imp->model_stream << "% adjacency " << p << " maps to " << t << '\n';
 }
 
 auto Proof::create_adjacency_constraint(int p, int q, int t, const vector<int> & uu, const vector<int> & cancel,
@@ -193,8 +193,8 @@ auto Proof::finalise_model() -> void
 {
     unique_ptr<ostream> f = make_unique<ofstream>(_imp->opb_filename);
 
-    *f << "* #variable= " << (_imp->variable_mappings.size() + _imp->binary_variable_mappings.size() + _imp->connected_variable_mappings.size() + _imp->connected_variable_mappings_aux.size())
-       << " #constraint= " << _imp->nb_constraints << '\n';
+    *f << "% #variable= " << (_imp->variable_mappings.size() + _imp->binary_variable_mappings.size() + _imp->connected_variable_mappings.size() + _imp->connected_variable_mappings_aux.size())
+       << " #constraint= " << _imp->nb_constraints << ";\n";
     copy(istreambuf_iterator<char>{_imp->model_prelude_stream}, istreambuf_iterator<char>{}, ostreambuf_iterator<char>{*f});
     _imp->model_prelude_stream.clear();
     copy(istreambuf_iterator<char>{_imp->model_stream}, istreambuf_iterator<char>{}, ostreambuf_iterator<char>{*f});
@@ -205,7 +205,7 @@ auto Proof::finalise_model() -> void
 
     _imp->proof_stream = make_unique<ofstream>(_imp->log_filename);
 
-    *_imp->proof_stream << "pseudo-Boolean proof version 3.0\n";
+    *_imp->proof_stream << "pseudo-Boolean proof version 3.0;\n";
 
     *_imp->proof_stream << "f " << _imp->nb_constraints << " ;\n";
     _imp->proof_line += _imp->nb_constraints;
@@ -226,24 +226,24 @@ auto Proof::finish_unsat_proof() -> void
 
 auto Proof::finish_sat_proof() -> void
 {
-    *_imp->proof_stream << "output NONE\n"
-        << "conclusion SAT\n"
-        << "end pseudo-Boolean proof\n";
+    *_imp->proof_stream << "output NONE;\n"
+        << "conclusion SAT;\n"
+        << "end pseudo-Boolean proof;\n";
 }
 
 auto Proof::finish_unknown_proof() -> void
 {
-    *_imp->proof_stream << "output NONE\n"
-        << "conclusion NONE\n"
-        << "end pseudo-Boolean proof\n";
+    *_imp->proof_stream << "output NONE;\n"
+        << "conclusion NONE;\n"
+        << "end pseudo-Boolean proof;\n";
 }
 
 auto Proof::finish_optimisation_proof(int size) -> void
 {
     *_imp->proof_stream << "rup" << _imp->objective_sum.str() << " >= " << size << ";\n";
-    *_imp->proof_stream << "output NONE\n"
-        << "conclusion BOUNDS " << size << " " << size << '\n'
-        << "end pseudo-Boolean proof\n";
+    *_imp->proof_stream << "output NONE;\n"
+        << "conclusion BOUNDS " << size << " " << size << ";\n"
+        << "end pseudo-Boolean proof;\n";
 }
 
 auto Proof::failure_due_to_pattern_bigger_than_target() -> void
@@ -587,7 +587,7 @@ auto Proof::post_solution(const vector<int> & solution) -> void
     *_imp->proof_stream << "solx";
     for (auto & v : solution)
         *_imp->proof_stream << " x" << _imp->binary_variable_mappings[v];
-    *_imp->proof_stream << '\n';
+    *_imp->proof_stream << ";\n";
     ++_imp->proof_line;
 }
 
@@ -608,7 +608,7 @@ auto Proof::new_incumbent(const vector<tuple<NamedVertex, NamedVertex, bool>> & 
     *_imp->proof_stream << "o";
     for (auto & [var, val, t] : decisions)
         *_imp->proof_stream << " " << (t ? "" : "~") << "x" << _imp->variable_mappings[pair{var.first, val.first}];
-    *_imp->proof_stream << '\n';
+    *_imp->proof_stream << ";\n";
     _imp->objective_line = ++_imp->proof_line;
 }
 
@@ -1036,7 +1036,7 @@ auto Proof::colour_bound(const vector<vector<int>> & ccs) -> void
                 *_imp->proof_stream << " " << (i + 1) << " d";
             }
 
-            *_imp->proof_stream << '\n';
+            *_imp->proof_stream << ";\n";
             to_sum.push_back(++_imp->proof_line);
         }
         else if (cc.size() == 2) {
@@ -1076,7 +1076,7 @@ auto Proof::colour_bound(const vector<vector<int>> & ccs) -> void
 
         for (auto & t : to_sum)
             *_imp->proof_stream << " " << t << " +";
-        *_imp->proof_stream << '\n';
+        *_imp->proof_stream << ";\n";
         ++_imp->proof_line;
     }
 }
@@ -1113,7 +1113,7 @@ auto Proof::start_hom_clique_proof(const NamedVertex & p, vector<NamedVertex> &&
             *_imp->proof_stream << " +";
         first = false;
     }
-    *_imp->proof_stream << '\n';
+    *_imp->proof_stream << ";\n";
     _imp->objective_line = ++_imp->proof_line;
 
     *_imp->proof_stream << "% hom clique non edges for injectivity\n";
@@ -1208,7 +1208,7 @@ auto Proof::mcs_bound(
         for (auto & v : r)
             *_imp->proof_stream << " " << get<1>(_imp->injectivity_constraints[v]) << " +";
 
-        *_imp->proof_stream << '\n';
+        *_imp->proof_stream << ";\n";
         to_sum.push_back(to_string(++_imp->proof_line));
     }
 
@@ -1216,7 +1216,7 @@ auto Proof::mcs_bound(
         *_imp->proof_stream << "pol  " << _imp->objective_line;
         for (auto & t : to_sum)
             *_imp->proof_stream << " " << t << " +";
-        *_imp->proof_stream << '\n';
+        *_imp->proof_stream << ";\n";
         ++_imp->proof_line;
     }
 }
@@ -1228,7 +1228,7 @@ auto Proof::rewrite_mcs_objective(int pattern_size) -> void
         *_imp->proof_stream << "pol  " << _imp->objective_line;
         for (int v = 0; v < pattern_size; ++v)
             *_imp->proof_stream << " " << get<1>(_imp->at_most_one_value_constraints[v]) << " +";
-        *_imp->proof_stream << '\n';
+        *_imp->proof_stream << ";\n";
         _imp->objective_line = ++_imp->proof_line;
     }
 }


### PR DESCRIPTION
Now aligning _as far as I can tell_ with the new syntax of veriPB3.0:
- [x] p lines now all pol lines
- [x] all lines end with ;
- [x] all comments only % instead of * or %