### PR TITLE
Modernise build/CI and add proof-verification test scaffolding

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,28 +6,27 @@ on:
   pull_request:
     branches: [ "master" ]
 
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-
 jobs:
-  job:
+  build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04, macos-14, macos-latest ] # macos-14 and macos-15 as of 10/25
+        os: [ ubuntu-24.04, ubuntu-26.04, macos-15, macos-26 ]
 
     steps:
-    - name: Telling you what the matrix is
-      run: echo "matrix.os is [$MATRIX_OS]"
-      env:
-          MATRIX_OS: ${{ matrix.os }}
-
     - name: Checkout
       uses: actions/checkout@v4
+
+    - name: Install GMP (Linux)
+      if: startsWith(matrix.os, 'ubuntu')
+      run: sudo apt-get update && sudo apt-get install -y libgmp-dev
+
+    - name: Install GMP (macOS)
+      if: startsWith(matrix.os, 'macos')
+      run: brew install gmp
 
     - name: Fetch VeriPB
       run: git -c core.hooksPath=/dev/null clone --depth 1 https://gitlab.com/MIAOresearch/software/VeriPB.git
@@ -36,16 +35,36 @@ jobs:
       run: cargo install --path ./VeriPB
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake --preset release
 
     - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j4
+      run: cmake --build --preset release
 
     - name: Test
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}} -j4
+      run: ctest --preset release -j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu) --rerun-failed --output-on-failure
+
+  sanitize:
+    name: Sanitize (ubuntu-26.04)
+    runs-on: ubuntu-26.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install GMP
+      run: sudo apt-get update && sudo apt-get install -y libgmp-dev
+
+    - name: Fetch VeriPB
+      run: git -c core.hooksPath=/dev/null clone --depth 1 https://gitlab.com/MIAOresearch/software/VeriPB.git
+
+    - name: Install VeriPB using cargo
+      run: cargo install --path ./VeriPB
+
+    - name: Configure CMake (Sanitize)
+      run: cmake --preset sanitize
+
+    - name: Build (Sanitize)
+      run: cmake --build --preset sanitize
+
+    - name: Test (Sanitize)
+      run: ctest --preset sanitize -j $(nproc 2>/dev/null || sysctl -n hw.logicalcpu) --rerun-failed --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build
+build-debug
+build-sanitize
 perf.data
 perf.data.old
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.21)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -10,38 +10,71 @@ project(
         HOMEPAGE_URL "https://github.com/ciaranm/glasgow-subgraph-solver"
         LANGUAGES CXX)
 
-add_compile_options(-W)
-add_compile_options(-Wall)
+# Build type configuration.
+# Three types are supported: Release (default), Debug, and Sanitize.
+# See CMakePresets.json and the README for usage.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Release Debug Sanitize)
 
+# Per-type flags, applied automatically by CMake for the active build type on top
+# of the always-on flags set below.
+# Release: full optimisation. -march=native is added later (Release only) after the
+#   compiler capability check.
+set(CMAKE_CXX_FLAGS_RELEASE "-O3"
+    CACHE STRING "Flags for release builds")
+# Debug: no optimisation so the debugger can follow every step.
+set(CMAKE_CXX_FLAGS_DEBUG "-O0"
+    CACHE STRING "Flags for debug builds")
+# Sanitize: light optimisation keeps stack traces readable while ASan + UBSan catch
+#   memory errors and undefined behaviour.
+set(CMAKE_CXX_FLAGS_SANITIZE "-O1 -fsanitize=address,undefined -fno-omit-frame-pointer"
+    CACHE STRING "Flags for sanitizer builds (ASan + UBSan)")
+set(CMAKE_EXE_LINKER_FLAGS_SANITIZE "-fsanitize=address,undefined"
+    CACHE STRING "Linker flags for sanitizer builds")
+set(CMAKE_SHARED_LINKER_FLAGS_SANITIZE "-fsanitize=address,undefined"
+    CACHE STRING "Linker flags for sanitizer builds")
+
+# Compiler flag checks always run so results are available below.
 include(CheckCXXCompilerFlag)
 unset(COMPILER_SUPPORTS_MARCH_NATIVE CACHE)
 CHECK_CXX_COMPILER_FLAG(-march=native COMPILER_SUPPORTS_MARCH_NATIVE)
-if (COMPILER_SUPPORTS_MARCH_NATIVE)
-    add_compile_options(-march=native)
-endif (COMPILER_SUPPORTS_MARCH_NATIVE)
 
 unset(COMPILER_SUPPORTS_NO_RESTRICT CACHE)
 CHECK_CXX_COMPILER_FLAG(-Wno-restrict COMPILER_SUPPORTS_NO_RESTRICT)
-if (COMPILER_SUPPORTS_NO_RESTRICT)
-    add_compile_options(-Wno-restrict) # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104336
-endif (COMPILER_SUPPORTS_NO_RESTRICT)
 
 unset(COMPILER_SUPPORTS_NO_STRINGOP_OVERREAD CACHE)
 CHECK_CXX_COMPILER_FLAG(-Wno-stringop-overread COMPILER_SUPPORTS_NO_STRINGOP_OVERREAD)
-if (COMPILER_SUPPORTS_NO_STRINGOP_OVERREAD)
-    add_compile_options(-Wno-stringop-overread) # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104336
-endif (COMPILER_SUPPORTS_NO_STRINGOP_OVERREAD)
 
-add_compile_options(-g)
-add_compile_options(-g3)
-add_compile_options(-gdwarf-3)
-add_compile_options(-pthread)
+# Global compile/link options only apply when building as the top-level project.
+# When embedded as a subproject via FetchContent the parent controls these settings.
+if(PROJECT_IS_TOP_LEVEL)
+    add_compile_options(-W)
+    add_compile_options(-Wall)
 
-add_link_options(-pthread)
+    if(COMPILER_SUPPORTS_NO_RESTRICT)
+        add_compile_options(-Wno-restrict) # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104336
+    endif()
+    if(COMPILER_SUPPORTS_NO_STRINGOP_OVERREAD)
+        add_compile_options(-Wno-stringop-overread) # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104336
+    endif()
 
-if (NOT GCS_DEBUG_MODE)
-    add_compile_options(-O3)
-endif (NOT GCS_DEBUG_MODE)
+    # Always include full debug info, even in release builds, so crash reports are useful.
+    add_compile_options(-g)
+    add_compile_options(-g3)
+    add_compile_options(-gdwarf-3)
+    add_compile_options(-pthread)
+    add_link_options(-pthread)
+
+    # Native CPU tuning is worthwhile for release performance but unhelpful for
+    # debugging or for portable (e.g. sanitizer) builds.
+    if(COMPILER_SUPPORTS_MARCH_NATIVE)
+        add_compile_options($<$<CONFIG:Release>:-march=native>)
+    endif()
+endif()
+
+enable_testing()
 
 Include(FetchContent)
 Set(FETCHCONTENT_QUIET FALSE)
@@ -61,7 +94,10 @@ FetchContent_MakeAvailable(cxxopts)
 
 SET(CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS ON)
 
-enable_testing()
+# VeriPB, if present, is used by the proof-verification tests (see gss/CMakeLists.txt).
+# Tests that need it are only registered when it is found, so a checkout without
+# VeriPB still builds and runs the rest of the suite.
+find_program(VERIPB_EXECUTABLE veripb)
 
 include_directories(.)
 add_subdirectory(gss)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,72 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 21,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "release",
+            "displayName": "Release",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "debug",
+            "displayName": "Debug",
+            "binaryDir": "${sourceDir}/build-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "sanitize",
+            "displayName": "Sanitize (ASan + UBSan)",
+            "binaryDir": "${sourceDir}/build-sanitize",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Sanitize"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "release",
+            "configurePreset": "release",
+            "jobs": 0
+        },
+        {
+            "name": "debug",
+            "configurePreset": "debug",
+            "jobs": 0
+        },
+        {
+            "name": "sanitize",
+            "configurePreset": "sanitize",
+            "jobs": 0
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "release",
+            "configurePreset": "release",
+            "output": { "outputOnFailure": true }
+        },
+        {
+            "name": "debug",
+            "configurePreset": "debug",
+            "output": { "outputOnFailure": true }
+        },
+        {
+            "name": "sanitize",
+            "configurePreset": "sanitize",
+            "output": { "outputOnFailure": true },
+            "environment": {
+                "ASAN_OPTIONS": "detect_leaks=1:halt_on_error=1",
+                "UBSAN_OPTIONS": "halt_on_error=1:print_stacktrace=1"
+            }
+        }
+    ]
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,3 +17,48 @@ target_link_libraries(create_random_graph PRIVATE cxxopts)
 
 add_executable(convert_to_lad convert_to_lad.cc)
 target_link_libraries(convert_to_lad PRIVATE cxxopts)
+
+# Proof-verification tests: run the solver with proof logging on a small instance
+# and check the resulting proof with VeriPB. Only registered when VeriPB was found
+# at configure time (find_program in the top-level CMakeLists), so a checkout
+# without VeriPB still builds and runs the rest of the suite.
+if(VERIPB_EXECUTABLE)
+    set(GSS_PROOF_RUNNER ${CMAKE_SOURCE_DIR}/test-instances/verify_proof.bash)
+    set(GSS_INSTANCES ${CMAKE_SOURCE_DIR}/test-instances)
+
+    # Register a proof test that VeriPB is expected to verify.
+    function(gss_add_proof_test name)
+        add_test(NAME ${name}
+            COMMAND ${GSS_PROOF_RUNNER}
+                $<TARGET_FILE:glasgow_subgraph_solver> ${VERIPB_EXECUTABLE}
+                ${CMAKE_CURRENT_BINARY_DIR} ${name} -- ${ARGN})
+    endfunction()
+
+    # Register a proof test that is currently BROKEN (tracked, not yet fixed). It is
+    # marked WILL_FAIL, so the suite stays green while the proof fails to verify;
+    # once the underlying bug is fixed the test will start passing and ctest will
+    # report it as a failure, prompting removal of the WILL_FAIL marker.
+    # Root causes are documented in issues #49 and #50.
+    function(gss_add_known_broken_proof_test name)
+        gss_add_proof_test(${name} ${ARGN})
+        set_tests_properties(${name} PROPERTIES WILL_FAIL TRUE)
+    endfunction()
+
+    # --- Currently verifying: UNSAT / refutation proofs ---
+    gss_add_proof_test(proof_unsat_loopy_induced
+        --induced --format lad ${GSS_INSTANCES}/small ${GSS_INSTANCES}/large)
+    gss_add_proof_test(proof_unsat_loopless_induced
+        --induced ${GSS_INSTANCES}/c3.csv ${GSS_INSTANCES}/trident.csv)
+
+    # --- Currently broken: SAT / solution proofs (see issues #49 and #50) ---
+    # (1) decision: GSS emits 'solx' (which needs a preserved set) where 'sol' is wanted.
+    gss_add_known_broken_proof_test(proof_sat_loopless_decision_KNOWN_BROKEN
+        ${GSS_INSTANCES}/trident.csv ${GSS_INSTANCES}/longtrident.csv)
+    # (2) enumeration: 'solx' requires a 'preserved:' set that GSS never emits.
+    gss_add_known_broken_proof_test(proof_sat_loopless_count_KNOWN_BROKEN
+        --count-solutions ${GSS_INSTANCES}/trident.csv ${GSS_INSTANCES}/longtrident.csv)
+    # (3) loop encoding: the self-loop->self-loop term is dropped from the adjacency
+    #     constraint, so a valid loop-preserving solution falsifies the model.
+    gss_add_known_broken_proof_test(proof_sat_loopy_decision_KNOWN_BROKEN
+        --format lad ${GSS_INSTANCES}/small ${GSS_INSTANCES}/large)
+endif()

--- a/test-instances/verify_proof.bash
+++ b/test-instances/verify_proof.bash
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Run the subgraph solver with proof logging on an instance, then check the proof
+# with VeriPB. Used by the ctest proof-verification suite (see src/CMakeLists.txt).
+#
+# Usage:
+#   verify_proof.bash <solver> <veripb> <workdir> <tag> -- <solver-args...>
+#
+# Exits 0 iff VeriPB prints "VERIFIED". The solver is always run with the proof-
+# logging-compatible flags (--no-supplementals --no-clique-detection --no-nds);
+# any further arguments (e.g. --induced, --count-solutions, the instance files)
+# come after the "--".
+#
+# Known-broken cases (currently SAT / solution proofs, see dev_docs/cleanup-plan.md)
+# are registered in CMake with the WILL_FAIL property, so this script stays simple:
+# it just reports whether the proof verifies.
+
+set -u
+
+if [ "$#" -lt 5 ]; then
+    echo "usage: $0 <solver> <veripb> <workdir> <tag> -- <solver-args...>" 1>&2
+    exit 2
+fi
+
+solver="$1"
+veripb="$2"
+workdir="$3"
+tag="$4"
+shift 4
+
+if [ "${1:-}" = "--" ]; then
+    shift
+fi
+
+proof="${workdir}/proof_${tag}"
+
+"${solver}" --no-supplementals --no-clique-detection --no-nds --prove "${proof}" "$@" > "${proof}.solver.log" 2>&1
+solver_status=$?
+if [ "${solver_status}" -ne 0 ]; then
+    echo "solver exited with status ${solver_status}:" 1>&2
+    cat "${proof}.solver.log" 1>&2
+    exit 1
+fi
+
+veripb_out=$("${veripb}" "${proof}.opb" "${proof}.pbp" 2>&1)
+echo "${veripb_out}"
+
+if echo "${veripb_out}" | grep -q 'VERIFIED'; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Modernises the build system and CI (borrowing selectively from the Glasgow Constraint Solver) and adds the first piece of test scaffolding: **proof verification under VeriPB**, which CI previously never ran.

### Build system
- `CMakePresets.json` — `release` / `debug` / `sanitize` presets.
- A real `Sanitize` build type (`-O1 -fsanitize=address,undefined`) and `PROJECT_IS_TOP_LEVEL` guards so the library embeds cleanly via FetchContent.
- `-march=native` restricted to Release builds.
- `GCS_DEBUG_MODE` retired in favour of `-DCMAKE_BUILD_TYPE=Debug` / the `debug` preset.

### CI (`.github/workflows/cmake.yml`)
- Modern OS matrix (ubuntu-24.04/26.04, macos-15/26).
- Explicit per-OS GMP install.
- Presets-based configure/build/test with `ctest --rerun-failed --output-on-failure`.
- A dedicated **sanitize job** (ASan + UBSan).

### Proof-verification test scaffolding
`test-instances/verify_proof.bash`, registered in `src/CMakeLists.txt` when VeriPB is found:
- **2 UNSAT proofs** that VeriPB verifies (normal passing tests).
- **3 SAT/solution proofs that are currently broken**, registered as `WILL_FAIL` tripwires so the suite stays green while tracking them — each will start failing (alerting us) once fixed.

Previously CI only ran the two Catch2 tests and **never invoked VeriPB**, which is how the SAT-proof breakage went unnoticed.

### Known-broken SAT proofs (tracked here, fixed in a separate proof workstream alongside `cake_pb_iso`)
1. Decision proofs emit `solx` (the enumeration rule, which needs an OPB `preserved:` set) where `sol` is wanted.
2. Enumeration proofs need `solx` **and** a `preserved:` set GSS never emits.
3. The self-loop→self-loop adjacency term is dropped from the model, so a valid loop-preserving solution falsifies it.

Root-cause analysis and the wider cleanup roadmap are in `dev_docs/cleanup-plan.md`.

## Test plan
- [x] `cmake --preset release && cmake --build --preset release && ctest --preset release` — 7/7 pass.
- [x] `cmake --preset sanitize && cmake --build --preset sanitize && ctest --preset sanitize` — 7/7 pass under ASan/UBSan.
- [ ] macOS CI lanes — not verifiable locally; Homebrew GMP discovery may need a tweak on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
