### PR TITLE
Add unit tests for the pure data structures

### DIFF
--- a/gss/CMakeLists.txt
+++ b/gss/CMakeLists.txt
@@ -54,3 +54,15 @@ add_test(NAME subgraph_isomorphism_test COMMAND $<TARGET_FILE:subgraph_isomorphi
 add_executable(homomorphism_test homomorphism_test.cc)
 target_link_libraries(homomorphism_test PRIVATE glasgow_subgraphs Catch2::Catch2WithMain)
 add_test(NAME homomorphism_test COMMAND $<TARGET_FILE:homomorphism_test>)
+
+add_executable(restarts_test restarts_test.cc)
+target_link_libraries(restarts_test PRIVATE glasgow_subgraphs Catch2::Catch2WithMain)
+add_test(NAME restarts_test COMMAND $<TARGET_FILE:restarts_test>)
+
+add_executable(loooong_test loooong_test.cc)
+target_link_libraries(loooong_test PRIVATE glasgow_subgraphs Catch2::Catch2WithMain)
+add_test(NAME loooong_test COMMAND $<TARGET_FILE:loooong_test>)
+
+add_executable(svo_bitset_test innards/svo_bitset_test.cc)
+target_link_libraries(svo_bitset_test PRIVATE glasgow_subgraphs Catch2::Catch2WithMain)
+add_test(NAME svo_bitset_test COMMAND $<TARGET_FILE:svo_bitset_test>)

--- a/gss/innards/svo_bitset_test.cc
+++ b/gss/innards/svo_bitset_test.cc
@@ -1,0 +1,154 @@
+#include <gss/innards/svo_bitset.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace gss::innards;
+
+namespace
+{
+    // SVOBitset stores up to 16 64-bit words inline ("short") and spills to the heap
+    // ("long") beyond that. Every behavioural test is run at a small size (<= 1024
+    // bits, inline) and a large size (> 1024 bits, heap) so both representations and
+    // the boundary between them are exercised.
+    constexpr unsigned small_bits = 128;  // 2 words, inline
+    constexpr unsigned large_bits = 2048; // 32 words, heap
+
+    auto check_basic_ops(unsigned size) -> void
+    {
+        SVOBitset b(size, 0);
+        CHECK_FALSE(b.any());
+        CHECK(b.count() == 0);
+        CHECK(b.find_first() == SVOBitset::npos);
+
+        b.set(5);
+        b.set(63);
+        b.set(64);
+        b.set(100);
+        CHECK(b.any());
+        CHECK(b.count() == 4);
+        CHECK(b.test(5));
+        CHECK(b.test(64));
+        CHECK_FALSE(b.test(6));
+        CHECK(b.find_first() == 5);
+
+        b.reset(5);
+        CHECK_FALSE(b.test(5));
+        CHECK(b.count() == 3);
+        CHECK(b.find_first() == 63);
+
+        b.reset();
+        CHECK_FALSE(b.any());
+        CHECK(b.count() == 0);
+        CHECK(b.find_first() == SVOBitset::npos);
+    }
+
+    auto check_bitwise_ops(unsigned size) -> void
+    {
+        SVOBitset a(size, 0), c(size, 0);
+        a.set(1);
+        a.set(2);
+        a.set(3);
+        c.set(2);
+        c.set(3);
+        c.set(4);
+
+        SVOBitset intersection = a;
+        intersection &= c;
+        CHECK(intersection.count() == 2);
+        CHECK(intersection.test(2));
+        CHECK(intersection.test(3));
+        CHECK_FALSE(intersection.test(1));
+
+        SVOBitset uni = a;
+        uni |= c;
+        CHECK(uni.count() == 4);
+        CHECK(uni.test(1));
+        CHECK(uni.test(4));
+
+        SVOBitset difference = a;
+        difference.intersect_with_complement(c);
+        CHECK(difference.count() == 1);
+        CHECK(difference.test(1));
+        CHECK_FALSE(difference.test(2));
+    }
+
+    auto check_copy_independence(unsigned size) -> void
+    {
+        SVOBitset a(size, 0);
+        a.set(10);
+        a.set(20);
+
+        SVOBitset copy_constructed = a;
+        copy_constructed.set(30);
+        CHECK(a.count() == 2); // original untouched
+        CHECK_FALSE(a.test(30));
+        CHECK(copy_constructed.count() == 3);
+
+        SVOBitset copy_assigned(size, 0);
+        copy_assigned = a;
+        copy_assigned.reset(10);
+        CHECK(a.test(10)); // original untouched
+        CHECK_FALSE(copy_assigned.test(10));
+        CHECK(copy_assigned.test(20));
+    }
+}
+
+TEST_CASE("SVOBitset basic operations, inline")
+{
+    check_basic_ops(small_bits);
+}
+
+TEST_CASE("SVOBitset basic operations, heap")
+{
+    check_basic_ops(large_bits);
+}
+
+TEST_CASE("SVOBitset bitwise operations, inline")
+{
+    check_bitwise_ops(small_bits);
+}
+
+TEST_CASE("SVOBitset bitwise operations, heap")
+{
+    check_bitwise_ops(large_bits);
+}
+
+TEST_CASE("SVOBitset copies are independent, inline")
+{
+    check_copy_independence(small_bits);
+}
+
+TEST_CASE("SVOBitset copies are independent, heap")
+{
+    check_copy_independence(large_bits);
+}
+
+TEST_CASE("SVOBitset addresses bits in the heap region")
+{
+    SVOBitset b(large_bits, 0);
+    b.set(1025);
+    b.set(2000);
+    CHECK(b.test(1025));
+    CHECK(b.test(2000));
+    CHECK(b.count() == 2);
+    CHECK(b.find_first() == 1025);
+}
+
+TEST_CASE("SVOBitset copy-assignment across the inline/heap boundary")
+{
+    SVOBitset small(small_bits, 0);
+    small.set(5);
+    SVOBitset large(large_bits, 0);
+    large.set(1500);
+
+    SVOBitset target(small_bits, 0);
+    target = large; // inline -> heap (allocates)
+    CHECK(target.test(1500));
+    CHECK(target.count() == 1);
+
+    target = small; // heap -> inline (frees)
+    CHECK(target.test(5));
+    // target is now a 128-bit bitset again, so bit 1500 is out of range and must
+    // not be probed; count() == 1 confirms the large bit is gone.
+    CHECK(target.count() == 1);
+}

--- a/gss/loooong_test.cc
+++ b/gss/loooong_test.cc
@@ -1,0 +1,109 @@
+#include <gss/loooong.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sstream>
+#include <string>
+#include <utility>
+
+using namespace gss;
+
+using std::string;
+using std::stringstream;
+
+namespace
+{
+    auto to_string(const loooong & x) -> string
+    {
+        stringstream s;
+        s << x;
+        return s.str();
+    }
+}
+
+TEST_CASE("loooong construction, equality and printing")
+{
+    CHECK(loooong{42} == loooong{42L});
+    CHECK(loooong{42} == loooong{42UL});
+    CHECK(loooong{-5} != loooong{5});
+
+    CHECK(to_string(loooong{0}) == "0");
+    CHECK(to_string(loooong{12345}) == "12345");
+    CHECK(to_string(loooong{-12345}) == "-12345");
+}
+
+TEST_CASE("loooong arithmetic operators")
+{
+    const loooong a{20}, b{7};
+    CHECK(a + b == loooong{27});
+    CHECK(a - b == loooong{13});
+    CHECK(a * b == loooong{140});
+    CHECK(a / b == loooong{2}); // truncating division
+    CHECK(loooong{3} - loooong{10} == loooong{-7});
+}
+
+TEST_CASE("loooong compound assignment operators")
+{
+    loooong c{10};
+    c += loooong{5};
+    CHECK(c == loooong{15});
+    c -= loooong{20};
+    CHECK(c == loooong{-5});
+    c *= loooong{4};
+    CHECK(c == loooong{-20});
+    c /= loooong{3}; // -20 / 3 truncates toward zero
+    CHECK(c == loooong{-6});
+    ++c;
+    CHECK(c == loooong{-5});
+}
+
+TEST_CASE("loooong comparisons")
+{
+    CHECK(loooong{3} < loooong{5});
+    CHECK(loooong{5} > loooong{3});
+    CHECK(loooong{5} <= loooong{5});
+    CHECK(loooong{5} >= loooong{5});
+    CHECK(loooong{-1} < loooong{0});
+}
+
+TEST_CASE("loooong handles values beyond 64 bits")
+{
+    // 2^64 = 18446744073709551616, one more bit than unsigned long long holds.
+    loooong power{1};
+    for (int i = 0; i < 64; ++i)
+        power *= loooong{2};
+    CHECK(to_string(power) == "18446744073709551616");
+
+    // 25! = 15511210043330985984000000.
+    loooong factorial{1};
+    for (int i = 1; i <= 25; ++i)
+        factorial *= loooong{i};
+    CHECK(to_string(factorial) == "15511210043330985984000000");
+    CHECK(factorial > loooong{0});
+}
+
+TEST_CASE("loooong gcd")
+{
+    CHECK(gcd(loooong{12}, loooong{18}) == loooong{6});
+    CHECK(gcd(loooong{17}, loooong{5}) == loooong{1});
+    CHECK(gcd(loooong{0}, loooong{9}) == loooong{9});
+}
+
+TEST_CASE("loooong copies and moves are independent")
+{
+    loooong a{100};
+
+    loooong copy{a};
+    copy += loooong{1};
+    CHECK(a == loooong{100}); // original untouched
+    CHECK(copy == loooong{101});
+
+    loooong assigned;
+    assigned = a;
+    assigned += loooong{5};
+    CHECK(a == loooong{100});
+    CHECK(assigned == loooong{105});
+
+    loooong moved{std::move(copy)};
+    CHECK(moved == loooong{101});
+}

--- a/gss/restarts_test.cc
+++ b/gss/restarts_test.cc
@@ -1,0 +1,143 @@
+#include <gss/restarts.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+using namespace gss;
+
+using std::atomic;
+using std::unique_ptr;
+using std::vector;
+
+using std::chrono::hours;
+using std::chrono::milliseconds;
+
+namespace
+{
+    // Run a schedule forward one restart's worth of backtracks, returning how many
+    // backtracks it took to trigger the restart.
+    auto backtracks_until_restart(RestartsSchedule & schedule) -> long long
+    {
+        long long n = 0;
+        while (! schedule.should_restart()) {
+            schedule.did_a_backtrack();
+            ++n;
+        }
+        schedule.did_a_restart();
+        return n;
+    }
+
+    auto first_restart_lengths(RestartsSchedule & schedule, unsigned how_many) -> vector<long long>
+    {
+        vector<long long> lengths;
+        for (unsigned i = 0; i < how_many; ++i)
+            lengths.push_back(backtracks_until_restart(schedule));
+        return lengths;
+    }
+}
+
+TEST_CASE("NoRestartsSchedule never restarts")
+{
+    NoRestartsSchedule schedule;
+    CHECK_FALSE(schedule.might_restart());
+    CHECK_FALSE(schedule.should_restart());
+
+    for (int i = 0; i < 1000; ++i) {
+        schedule.did_a_backtrack();
+        CHECK_FALSE(schedule.should_restart());
+    }
+}
+
+TEST_CASE("LubyRestartsSchedule follows the Luby sequence")
+{
+    // The (unscaled) Luby sequence.
+    const vector<long long> luby{1, 1, 2, 1, 1, 2, 4, 1, 1, 2, 1, 1, 2, 4, 8};
+
+    SECTION("multiplier 1")
+    {
+        LubyRestartsSchedule schedule{1};
+        CHECK(schedule.might_restart());
+        CHECK(first_restart_lengths(schedule, luby.size()) == luby);
+    }
+
+    SECTION("scaled by a multiplier")
+    {
+        const long long multiplier = 7;
+        LubyRestartsSchedule schedule{multiplier};
+        vector<long long> expected;
+        for (auto v : luby)
+            expected.push_back(v * multiplier);
+        CHECK(first_restart_lengths(schedule, luby.size()) == expected);
+    }
+}
+
+TEST_CASE("GeometricRestartsSchedule grows by its multiplier")
+{
+    SECTION("doubling")
+    {
+        GeometricRestartsSchedule schedule{10.0, 2.0};
+        CHECK(schedule.might_restart());
+        CHECK(first_restart_lengths(schedule, 4) == vector<long long>{10, 20, 40, 80});
+    }
+
+    SECTION("constant when the multiplier is 1")
+    {
+        GeometricRestartsSchedule schedule{15.0, 1.0};
+        CHECK(first_restart_lengths(schedule, 4) == vector<long long>{15, 15, 15, 15});
+    }
+}
+
+TEST_CASE("SyncedRestartSchedule mirrors its synchroniser")
+{
+    atomic<bool> trigger{false};
+    SyncedRestartSchedule schedule{trigger};
+
+    CHECK(schedule.might_restart());
+    CHECK_FALSE(schedule.should_restart());
+
+    trigger = true;
+    CHECK(schedule.should_restart());
+
+    trigger = false;
+    CHECK_FALSE(schedule.should_restart());
+}
+
+TEST_CASE("TimedRestartsSchedule respects the minimum backtracks / time gate")
+{
+    // With a duration of an hour, the time condition cannot be met during the test,
+    // so the schedule must never ask to restart however many backtracks happen.
+    TimedRestartsSchedule schedule{hours{1}, 10};
+    CHECK(schedule.might_restart());
+
+    for (int i = 0; i < 100; ++i) {
+        schedule.did_a_backtrack();
+        CHECK_FALSE(schedule.should_restart());
+    }
+}
+
+TEST_CASE("RestartsSchedule clone produces an independent equivalent schedule")
+{
+    SECTION("Luby")
+    {
+        LubyRestartsSchedule original{1};
+        // Advance the original past its first two restarts.
+        backtracks_until_restart(original);
+        backtracks_until_restart(original);
+
+        unique_ptr<RestartsSchedule> copy{original.clone()};
+
+        // The clone resumes from the same point in the sequence as the original.
+        CHECK(backtracks_until_restart(*copy) == backtracks_until_restart(original));
+        CHECK(backtracks_until_restart(*copy) == backtracks_until_restart(original));
+    }
+
+    SECTION("None")
+    {
+        NoRestartsSchedule original;
+        unique_ptr<RestartsSchedule> copy{original.clone()};
+        CHECK_FALSE(copy->should_restart());
+    }
+}


### PR DESCRIPTION
## Summary

First batch of **Phase 2 unit tests** (see `dev_docs/cleanup-plan.md`): the pure, deterministic data structures, which previously had **zero** coverage. Cheapest-first, to establish the Catch2 expansion pattern.

- **`restarts_test`** — `NoRestarts` / `Luby` / `Geometric` / `Synced` / `Timed` schedules: verifies the Luby backtrack sequence (`1,1,2,1,1,2,4,…`, scaled by the multiplier), the geometric growth sequence, the synchroniser and minimum-backtrack/time gates, and `clone()`.
- **`loooong_test`** — construction, arithmetic, compound assignment, comparisons (`<=>`), `gcd`, copy/move independence, and **values beyond 64 bits** (`2^64`, `25!`) checked via the stream operator.
- **`svo_bitset_test`** — `set`/`test`/`reset`/`count`/`find_first` and the bitwise operators, each run at both the **inline** (≤16-word) and **heap** (>16-word) representations, plus copy independence and assignment across the inline/heap boundary.

## Notes
- All tests run clean under the **sanitize** preset (ASan + UBSan). Writing the bitset tests both (a) caught a latent out-of-bounds probe in an early version of my own test that only the sanitize lane exposed — good validation of #40's sanitize job — and (b) surfaced a harmless ~64× over-allocation in `SVOBitset(size, bits)`'s heap path, noted in the plan doc for the Phase 3 RAII cleanup.

## Test plan
- [x] `ctest --preset release` — 10/10 pass.
- [x] `ctest --preset sanitize` — 10/10 pass under ASan/UBSan.

Stacked on #40 (uses its presets + sanitize job); please merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
