### PR TITLE
Add format-reader tests; make readers istream-testable

### DIFF
--- a/gss/CMakeLists.txt
+++ b/gss/CMakeLists.txt
@@ -66,3 +66,7 @@ add_test(NAME loooong_test COMMAND $<TARGET_FILE:loooong_test>)
 add_executable(svo_bitset_test innards/svo_bitset_test.cc)
 target_link_libraries(svo_bitset_test PRIVATE glasgow_subgraphs Catch2::Catch2WithMain)
 add_test(NAME svo_bitset_test COMMAND $<TARGET_FILE:svo_bitset_test>)
+
+add_executable(formats_test formats/formats_test.cc)
+target_link_libraries(formats_test PRIVATE glasgow_subgraphs Catch2::Catch2WithMain)
+add_test(NAME formats_test COMMAND $<TARGET_FILE:formats_test>)

--- a/gss/formats/dimacs.cc
+++ b/gss/formats/dimacs.cc
@@ -2,18 +2,18 @@
 #include <gss/formats/graph_file_error.hh>
 #include <gss/formats/input_graph.hh>
 
-#include <fstream>
+#include <istream>
 #include <regex>
 
 using std::getline;
-using std::ifstream;
+using std::istream;
 using std::regex;
 using std::smatch;
 using std::stoi;
 using std::string;
 using std::to_string;
 
-auto read_dimacs(ifstream && infile, const string & filename) -> InputGraph
+auto read_dimacs(istream && infile, const string & filename) -> InputGraph
 {
     InputGraph result{0, false, false};
 

--- a/gss/formats/dimacs.hh
+++ b/gss/formats/dimacs.hh
@@ -12,6 +12,6 @@
  *
  * \throw GraphFileError
  */
-auto read_dimacs(std::ifstream && infile, const std::string & filename) -> InputGraph;
+auto read_dimacs(std::istream && infile, const std::string & filename) -> InputGraph;
 
 #endif

--- a/gss/formats/formats_test.cc
+++ b/gss/formats/formats_test.cc
@@ -1,0 +1,240 @@
+#include <gss/formats/csv.hh>
+#include <gss/formats/dimacs.hh>
+#include <gss/formats/graph_file_error.hh>
+#include <gss/formats/input_graph.hh>
+#include <gss/formats/lad.hh>
+#include <gss/formats/vfmcs.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sstream>
+#include <string>
+
+using std::string;
+using std::stringstream;
+
+namespace
+{
+    // Look a vertex up by name; fails the test loudly rather than dereferencing a
+    // disengaged optional if the name is missing.
+    auto id(const InputGraph & g, const string & name) -> int
+    {
+        auto v = g.vertex_from_name(name);
+        REQUIRE(v.has_value());
+        return *v;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CSV
+// ---------------------------------------------------------------------------
+
+TEST_CASE("read_csv: undirected edges")
+{
+    auto g = read_csv(stringstream{"a,b\nb,c\n"}, "g");
+    CHECK(g.size() == 3);
+    CHECK_FALSE(g.directed());
+    CHECK_FALSE(g.has_vertex_labels());
+    CHECK_FALSE(g.has_edge_labels());
+    CHECK(g.adjacent(id(g, "a"), id(g, "b")));
+    CHECK(g.adjacent(id(g, "b"), id(g, "a"))); // undirected: both directions
+    CHECK_FALSE(g.adjacent(id(g, "a"), id(g, "c")));
+    CHECK(g.number_of_directed_edges() == 4); // two undirected edges
+}
+
+TEST_CASE("read_csv: directed edges")
+{
+    auto g = read_csv(stringstream{"a>b\n"}, "g");
+    CHECK(g.directed());
+    CHECK(g.adjacent(id(g, "a"), id(g, "b")));
+    CHECK_FALSE(g.adjacent(id(g, "b"), id(g, "a")));
+    CHECK(g.number_of_directed_edges() == 1);
+}
+
+TEST_CASE("read_csv: vertex labels")
+{
+    auto g = read_csv(stringstream{"a,,red\nb,,blue\na,b\n"}, "g");
+    CHECK(g.size() == 2);
+    CHECK(g.has_vertex_labels());
+    CHECK(g.vertex_label(id(g, "a")) == "red");
+    CHECK(g.vertex_label(id(g, "b")) == "blue");
+}
+
+TEST_CASE("read_csv: edge labels")
+{
+    auto g = read_csv(stringstream{"a,b,red\n"}, "g");
+    CHECK(g.has_edge_labels());
+    CHECK(g.edge_label(id(g, "a"), id(g, "b")) == "red");
+    CHECK(g.edge_label(id(g, "b"), id(g, "a")) == "red");
+    // Quirk worth locking in: a labelled *undirected* CSV edge is built from two
+    // add_directed_edge calls, so the graph reports itself as directed.
+    CHECK(g.directed());
+    CHECK(g.number_of_directed_edges() == 2);
+}
+
+TEST_CASE("read_csv: self loops")
+{
+    auto g = read_csv(stringstream{"a,a\na,b\n"}, "g");
+    CHECK(g.loopy());
+    CHECK(g.adjacent(id(g, "a"), id(g, "a")));
+}
+
+TEST_CASE("read_csv: a line without a delimiter is an error")
+{
+    CHECK_THROWS_AS(read_csv(stringstream{"a,b\nnodelimiter\n"}, "g"), GraphFileError);
+}
+
+TEST_CASE("read_csv: non-printable characters in a name are rejected")
+{
+    CHECK_THROWS_AS(read_csv(stringstream{string("a\x01z,b\n")}, "g"), GraphFileError);
+}
+
+// ---------------------------------------------------------------------------
+// LAD
+// ---------------------------------------------------------------------------
+
+TEST_CASE("read_lad: undirected graph")
+{
+    // 3 vertices; vertex 0 adjacent to 1 and 2; 1 and 2 adjacent to 0.
+    auto g = read_lad(stringstream{"3  2 1 2  1 0  1 0"}, "g");
+    CHECK(g.size() == 3);
+    CHECK_FALSE(g.directed());
+    CHECK(g.adjacent(0, 1));
+    CHECK(g.adjacent(1, 0));
+    CHECK(g.adjacent(0, 2));
+    CHECK_FALSE(g.adjacent(1, 2));
+    CHECK(g.vertex_name(0) == "0");
+    CHECK(g.number_of_directed_edges() == 4);
+}
+
+TEST_CASE("read_lad: trailing assignments rename vertices")
+{
+    auto g = read_lad(stringstream{"2  1 1  1 0  0=alice 1=bob"}, "g");
+    CHECK(g.vertex_name(0) == "alice");
+    CHECK(g.vertex_name(1) == "bob");
+    CHECK(id(g, "alice") == 0);
+}
+
+TEST_CASE("read_directed_lad: edges are directed")
+{
+    auto g = read_directed_lad(stringstream{"2  1 1  0"}, "g");
+    CHECK(g.directed());
+    CHECK(g.adjacent(0, 1));
+    CHECK_FALSE(g.adjacent(1, 0));
+    CHECK(g.number_of_directed_edges() == 1);
+}
+
+TEST_CASE("read_vertex_labelled_lad: reads vertex labels")
+{
+    // size; then per vertex: <label> <degree> <neighbour>...
+    auto g = read_vertex_labelled_lad(stringstream{"2  5 1 1  7 1 0"}, "g");
+    CHECK(g.has_vertex_labels());
+    CHECK_FALSE(g.has_edge_labels());
+    CHECK(g.vertex_label(0) == "5");
+    CHECK(g.vertex_label(1) == "7");
+    CHECK(g.adjacent(0, 1));
+}
+
+TEST_CASE("read_labelled_lad: reads vertex and edge labels")
+{
+    // size; then per vertex: <vlabel> <degree> (<neighbour> <edgelabel>)...
+    auto g = read_labelled_lad(stringstream{"2  5 1 1 9  7 0"}, "g");
+    CHECK(g.has_vertex_labels());
+    CHECK(g.has_edge_labels());
+    CHECK(g.directed());
+    CHECK(g.vertex_label(0) == "5");
+    CHECK(g.edge_label(0, 1) == "9");
+}
+
+TEST_CASE("read_lad: an out-of-bounds edge is an error")
+{
+    CHECK_THROWS_AS(read_lad(stringstream{"2  1 5  0"}, "g"), GraphFileError);
+}
+
+TEST_CASE("read_lad: trailing junk is an error")
+{
+    CHECK_THROWS_AS(read_lad(stringstream{"2  1 1  1 0  notanassignment"}, "g"), GraphFileError);
+}
+
+// ---------------------------------------------------------------------------
+// DIMACS
+// ---------------------------------------------------------------------------
+
+TEST_CASE("read_dimacs: basic graph, 1-indexed")
+{
+    auto g = read_dimacs(stringstream{"p edge 3 2\ne 1 2\ne 2 3\n"}, "g");
+    CHECK(g.size() == 3);
+    CHECK(g.adjacent(0, 1)); // edge "1 2" -> 0-indexed 0-1
+    CHECK(g.adjacent(1, 2));
+    CHECK_FALSE(g.adjacent(0, 2));
+    CHECK(g.vertex_name(0) == "1"); // names are 1-indexed
+}
+
+TEST_CASE("read_dimacs: comments are ignored")
+{
+    auto g = read_dimacs(stringstream{"c a comment\nc another\np edge 2 1\ne 1 2\n"}, "g");
+    CHECK(g.size() == 2);
+    CHECK(g.adjacent(0, 1));
+}
+
+TEST_CASE("read_dimacs: an edge before the problem line is out of bounds")
+{
+    CHECK_THROWS_AS(read_dimacs(stringstream{"e 1 2\n"}, "g"), GraphFileError);
+}
+
+TEST_CASE("read_dimacs: multiple problem lines are an error")
+{
+    CHECK_THROWS_AS(read_dimacs(stringstream{"p edge 2 0\np edge 3 0\n"}, "g"), GraphFileError);
+}
+
+TEST_CASE("read_dimacs: an unparseable line is an error")
+{
+    CHECK_THROWS_AS(read_dimacs(stringstream{"p edge 2 1\nx 1 2\n"}, "g"), GraphFileError);
+}
+
+// ---------------------------------------------------------------------------
+// VFMCS (little-endian 16-bit binary)
+// ---------------------------------------------------------------------------
+
+namespace
+{
+    auto vfmcs_word(string & out, unsigned w) -> void
+    {
+        out.push_back(static_cast<char>(w & 0xff));
+        out.push_back(static_cast<char>((w >> 8) & 0xff));
+    }
+}
+
+TEST_CASE("read_unlabelled_undirected_vfmcs: basic graph")
+{
+    // 2 vertices, one undirected edge between them. Layout: size; one attribute
+    // word per vertex; then per vertex an edge count followed by (target, label)
+    // word pairs.
+    string bytes;
+    vfmcs_word(bytes, 2); // size
+    vfmcs_word(bytes, 0); // vertex 0 attribute
+    vfmcs_word(bytes, 0); // vertex 1 attribute
+    vfmcs_word(bytes, 1); // vertex 0 edge count
+    vfmcs_word(bytes, 1); // vertex 0 -> 1
+    vfmcs_word(bytes, 0); // edge label (ignored)
+    vfmcs_word(bytes, 0); // vertex 1 edge count
+
+    auto g = read_unlabelled_undirected_vfmcs(stringstream{bytes}, "g");
+    CHECK(g.size() == 2);
+    CHECK_FALSE(g.directed());
+    CHECK(g.adjacent(0, 1));
+    CHECK(g.adjacent(1, 0));
+    CHECK(g.number_of_directed_edges() == 2);
+}
+
+TEST_CASE("read_unlabelled_undirected_vfmcs: an out-of-bounds edge is an error")
+{
+    string bytes;
+    vfmcs_word(bytes, 1); // size 1
+    vfmcs_word(bytes, 0); // vertex 0 attribute
+    vfmcs_word(bytes, 1); // vertex 0 edge count
+    vfmcs_word(bytes, 5); // vertex 0 -> 5 (out of bounds)
+    vfmcs_word(bytes, 0); // edge label
+
+    CHECK_THROWS_AS(read_unlabelled_undirected_vfmcs(stringstream{bytes}, "g"), GraphFileError);
+}

--- a/gss/formats/lad.cc
+++ b/gss/formats/lad.cc
@@ -1,11 +1,11 @@
 #include <gss/formats/input_graph.hh>
 #include <gss/formats/lad.hh>
 
-#include <fstream>
+#include <istream>
 #include <map>
 #include <string>
 
-using std::ifstream;
+using std::istream;
 using std::map;
 using std::pair;
 using std::stoi;
@@ -14,14 +14,14 @@ using std::to_string;
 
 namespace
 {
-    auto read_word(ifstream & infile) -> int
+    auto read_word(istream & infile) -> int
     {
         int x;
         infile >> x;
         return x;
     }
 
-    auto read_any_lad(ifstream && infile, const string & filename,
+    auto read_any_lad(istream && infile, const string & filename,
         bool directed,
         bool vertex_labels,
         bool edge_labels) -> InputGraph
@@ -84,22 +84,22 @@ namespace
     }
 }
 
-auto read_lad(ifstream && infile, const string & filename) -> InputGraph
+auto read_lad(istream && infile, const string & filename) -> InputGraph
 {
     return read_any_lad(move(infile), filename, false, false, false);
 }
 
-auto read_directed_lad(ifstream && infile, const string & filename) -> InputGraph
+auto read_directed_lad(istream && infile, const string & filename) -> InputGraph
 {
     return read_any_lad(move(infile), filename, true, false, false);
 }
 
-auto read_labelled_lad(ifstream && infile, const string & filename) -> InputGraph
+auto read_labelled_lad(istream && infile, const string & filename) -> InputGraph
 {
     return read_any_lad(move(infile), filename, true, true, true);
 }
 
-auto read_vertex_labelled_lad(ifstream && infile, const string & filename) -> InputGraph
+auto read_vertex_labelled_lad(istream && infile, const string & filename) -> InputGraph
 {
     return read_any_lad(move(infile), filename, false, true, false);
 }

--- a/gss/formats/lad.hh
+++ b/gss/formats/lad.hh
@@ -12,27 +12,27 @@
  *
  * \throw GraphFileError
  */
-auto read_lad(std::ifstream && infile, const std::string & filename) -> InputGraph;
+auto read_lad(std::istream && infile, const std::string & filename) -> InputGraph;
 
 /**
  * Read a LAD format file into an InputGraph, treating edges as directed.
  *
  * \throw GraphFileError
  */
-auto read_directed_lad(std::ifstream && infile, const std::string & filename) -> InputGraph;
+auto read_directed_lad(std::istream && infile, const std::string & filename) -> InputGraph;
 
 /**
  * Read a Labelled LAD format file into an InputGraph.
  *
  * \throw GraphFileError
  */
-auto read_labelled_lad(std::ifstream && infile, const std::string & filename) -> InputGraph;
+auto read_labelled_lad(std::istream && infile, const std::string & filename) -> InputGraph;
 
 /**
  * Read a Vertex-Labelled LAD format file into an InputGraph.
  *
  * \throw GraphFileError
  */
-auto read_vertex_labelled_lad(std::ifstream && infile, const std::string & filename) -> InputGraph;
+auto read_vertex_labelled_lad(std::istream && infile, const std::string & filename) -> InputGraph;
 
 #endif

--- a/gss/formats/vfmcs.cc
+++ b/gss/formats/vfmcs.cc
@@ -1,17 +1,17 @@
 #include <gss/formats/graph_file_error.hh>
 #include <gss/formats/vfmcs.hh>
 
-#include <fstream>
+#include <istream>
 #include <string>
 
-using std::ifstream;
+using std::istream;
 using std::move;
 using std::string;
 using std::to_string;
 
 namespace
 {
-    auto read_word(ifstream & infile) -> unsigned
+    auto read_word(istream & infile) -> unsigned
     {
         unsigned char a, b;
         a = static_cast<unsigned char>(infile.get());
@@ -19,7 +19,7 @@ namespace
         return unsigned(a) | (unsigned(b) << 8);
     }
 
-    auto read_vfmcs(ifstream && infile, const string & filename, bool vertex_labels, bool directed) -> InputGraph
+    auto read_vfmcs(istream && infile, const string & filename, bool vertex_labels, bool directed) -> InputGraph
     {
         int size = read_word(infile);
         if (! infile)
@@ -72,17 +72,17 @@ namespace
     }
 }
 
-auto read_unlabelled_undirected_vfmcs(ifstream && infile, const string & filename) -> InputGraph
+auto read_unlabelled_undirected_vfmcs(istream && infile, const string & filename) -> InputGraph
 {
     return read_vfmcs(move(infile), filename, false, false);
 }
 
-auto read_vertex_labelled_undirected_vfmcs(ifstream && infile, const string & filename) -> InputGraph
+auto read_vertex_labelled_undirected_vfmcs(istream && infile, const string & filename) -> InputGraph
 {
     return read_vfmcs(move(infile), filename, true, false);
 }
 
-auto read_vertex_labelled_directed_vfmcs(std::ifstream && infile, const std::string & filename) -> InputGraph
+auto read_vertex_labelled_directed_vfmcs(std::istream && infile, const std::string & filename) -> InputGraph
 {
     return read_vfmcs(move(infile), filename, true, true);
 }

--- a/gss/formats/vfmcs.hh
+++ b/gss/formats/vfmcs.hh
@@ -7,10 +7,10 @@
 #include <iosfwd>
 #include <string>
 
-auto read_unlabelled_undirected_vfmcs(std::ifstream && infile, const std::string & filename) -> InputGraph;
+auto read_unlabelled_undirected_vfmcs(std::istream && infile, const std::string & filename) -> InputGraph;
 
-auto read_vertex_labelled_undirected_vfmcs(std::ifstream && infile, const std::string & filename) -> InputGraph;
+auto read_vertex_labelled_undirected_vfmcs(std::istream && infile, const std::string & filename) -> InputGraph;
 
-auto read_vertex_labelled_directed_vfmcs(std::ifstream && infile, const std::string & filename) -> InputGraph;
+auto read_vertex_labelled_directed_vfmcs(std::istream && infile, const std::string & filename) -> InputGraph;
 
 #endif


### PR DESCRIPTION
## Summary

Next **Phase 2** batch: tests for the **graph file format readers**, which had no direct coverage (only CSV, indirectly, via the homomorphism tests).

- **CSV** — undirected / directed / labelled edges, vertex labels, self-loops, a malformed line (no delimiter), and the non-printable-character name check.
- **LAD** — all four variants (`read_lad`, `read_directed_lad`, `read_vertex_labelled_lad`, `read_labelled_lad`), trailing `i=name` renames, and the out-of-bounds / trailing-junk error paths.
- **DIMACS** — 1-indexed parsing, comment handling, and the edge-before-`p` / multiple-`p` / unparseable-line errors.
- **VFMCS** — the little-endian 16-bit binary format (basic graph + out-of-bounds error), built from an in-memory byte string.

## Testability seam
To test the readers with in-memory `stringstream`s the way `read_csv` already can, their signatures are harmonised from `std::ifstream &&` to `std::istream &&`. The sole call site (`read_file_format.cc`) opens an `ifstream` and passes it, which binds to `istream &&` unchanged, and the readers only use `istream`-level operations (`>>`, `getline`, `get`, `peek`, `eof`) — so this is a pure seam, not a behaviour change. `run-tests.bash` and the real file-reading paths still pass.

A couple of quirks are deliberately locked in with comments (e.g. a labelled *undirected* CSV edge reports `directed() == true`), and the `--format` help/reality mismatch is noted in the plan for a follow-up doc fix.

## Test plan
- [x] `ctest --preset release` — 11/11 pass.
- [x] `ctest --preset sanitize` — 11/11 pass under ASan/UBSan.
- [x] `run-tests.bash` — pass (integration file-reading path).

Stacked on #41 (→ #40); please merge those first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
