### PR TITLE
Document architecture and proof logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,16 @@ program:
 And then you can produce and verify a log like this:
 
 ```shell session
-$ ./build/glasgow_subgraph_solver --no-supplementals --no-clique-detection --no-nds \
-    --prove myproof --proof-solutions pattern-file target-file
+$ ./build/glasgow_subgraph_solver --induced --no-supplementals --no-clique-detection --no-nds \
+    --prove myproof --format lad pattern-file target-file
 $ veripb myproof.opb myproof.pbp
 ```
 
-Note that most features are not yet supported with proof logging. This is a "not yet implemented"
-problem, not a fundamental restriction.
+This writes the pseudo-Boolean model to `myproof.opb` and the proof to `myproof.pbp`. Refutation
+(unsatisfiable) proofs verify; solution proofs are a work in progress. Most other features are not
+yet supported with proof logging — this is a "not yet implemented" problem, not a fundamental
+restriction. See [dev_docs/proof-logging.md](dev_docs/proof-logging.md) for the supported option
+combinations and the current status.
 
 Clique Solving
 --------------

--- a/dev_docs/architecture.md
+++ b/dev_docs/architecture.md
@@ -1,0 +1,119 @@
+# Architecture
+
+A developer's-eye map of the Glasgow Subgraph Solver: how the code is laid out, what the main
+components are, and how they fit together. For *using* the solvers see the [README](../README.md);
+for the proof-logging machinery see [proof-logging.md](proof-logging.md).
+
+## What's in the box
+
+One static library (`gss/`, target `glasgow_subgraphs`) and a handful of command-line drivers
+(`src/`). The library solves three related problems:
+
+| Problem | Public entry point | Header |
+| --- | --- | --- |
+| Subgraph isomorphism / homomorphism | `solve_homomorphism_problem` | `gss/homomorphism.hh` |
+| Clique (decision / maximum) | `solve_clique_problem` | `gss/clique.hh` |
+| Maximum common (connected) subgraph | `solve_common_subgraph_problem` | `gss/common_subgraph.hh` |
+
+The drivers are thin: they parse options with `cxxopts`, read graphs, fill in a `*Params` struct,
+call the matching `solve_*` function, and print the `*Result`.
+
+## Layers
+
+```
+            src/glasgow_subgraph_solver.cc   glasgow_clique_solver.cc   glasgow_common_subgraph_solver.cc
+                          │                          │                          │   (also create_random_graph, convert_to_lad)
+                          ▼                          ▼                          ▼
+  ┌───────────────────────────────────────────────────────────────────────────────────────┐
+  │ Public API  (gss/*.hh)                                                                   │
+  │   homomorphism · clique · common_subgraph · sip_decomposer                               │
+  │   HomomorphismParams / CliqueParams / CommonSubgraphParams   +   *Result structs         │
+  │   restarts · timeout · value_ordering · loooong · vertex_to_vertex_mapping               │
+  └───────────────────────────────────────────────────────────────────────────────────────┘
+                          │ uses
+                          ▼
+  ┌───────────────────────────────────────────────────────────────────────────────────────┐
+  │ Implementation detail  (gss/innards/*)                                                    │
+  │   homomorphism_model · homomorphism_searcher · homomorphism_domain · homomorphism_traits  │
+  │   cheap_all_different · graph_traits · watches (nogoods) · svo_bitset                      │
+  │   proof (VeriPB logging) · verify · lackey (external solver) · symmetries (GAP) · threads  │
+  └───────────────────────────────────────────────────────────────────────────────────────┘
+                          │ uses
+                          ▼
+  ┌───────────────────────────────────────────────────────────────────────────────────────┐
+  │ Graph input  (gss/formats/*)            Utilities  (gss/utils/*)                          │
+  │   InputGraph  +  readers: csv, lad, dimacs, vfmcs, read_file_format                       │
+  │   graph_file_error                       hashing_utils · vertex_name_map                   │
+  └───────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+The convention is that everything under `gss/innards/` is private to the library — callers should
+only need the headers directly under `gss/`. A few innards types do currently leak through the public
+API (the `Lackey` handle and `ProofOptions` on the `*Params` structs, and `SVOBitset` in a
+`CliqueParams` callback); these are deliberate extension points rather than accidents.
+
+## The homomorphism solver in more detail
+
+This is the largest and most general engine; the subgraph isomorphism and (non-)injective
+homomorphism variants are all configurations of it.
+
+- **`HomomorphismModel`** (`innards/homomorphism_model.{hh,cc}`) turns the two `InputGraph`s plus the
+  `HomomorphismParams` into the internal constraint model: it re-encodes the graphs as bitset
+  adjacency, builds the *supplemental graphs* (exact-path / distance-3 / k4 / extra shapes) used for
+  stronger filtering, precomputes degrees and neighbourhood-degree sequences, and seeds the initial
+  variable domains. The heavy lifting happens in `prepare()`.
+- **`HomomorphismDomain`** (`innards/homomorphism_domain.hh`) is one CP variable's domain: an
+  `SVOBitset` of still-possible target vertices plus bookkeeping.
+- **`HomomorphismSearcher`** (`innards/homomorphism_searcher.{hh,cc}`) is the backtracking engine:
+  variable/value ordering, constraint propagation (adjacency, all-different via
+  `cheap_all_different`, less-than / occurs-less symmetry constraints, optional lackey propagation),
+  restarts, and nogood recording via `Watches`. The propagation hot path is templated on
+  `<directed, has_edge_labels, induced, verbose_proofs>` so the per-node inner loop has no runtime
+  branches on those flags — a deliberate performance choice.
+- **`solve_homomorphism_problem`** (`homomorphism.cc`) wires these together: it sets up optional
+  proof logging, applies cheap early-exit heuristics (pattern bigger than target, the loop shortcut,
+  clique detection), builds the model, and dispatches to a sequential or threaded solver.
+
+`sip_decomposer` offers an alternative top level that solves subgraph isomorphism by decomposing the
+pattern into biconnected components.
+
+## The clique and common-subgraph solvers
+
+- **Clique** (`clique.{hh,cc}`) is a branch-and-bound maximum-clique solver using a greedy colouring
+  as both the bound and the branching heuristic, over `SVOBitset` adjacency, with the same
+  `Watches`-based nogoods and restarts. `CliqueParams::decide` switches it to a decision problem.
+- **Common subgraph** (`common_subgraph.{hh,cc}`) finds the maximum common *induced* subgraph by a
+  partition-refinement branch and bound. It can optionally be solved by reducing to a clique on the
+  association graph (`CommonSubgraphParams::clique`), and supports a connected variant. The clique
+  solver is reused for the reduction, which is why `clique.hh` exposes the `connected` callback and
+  the proof-extension hooks.
+
+## Cross-cutting pieces
+
+- **`InputGraph`** (`formats/input_graph.{hh,cc}`) is the format-agnostic graph the readers produce
+  and the solvers consume: a pimpl over an edge map, with vertex names/labels and edge labels. It is
+  deliberately not performance-tuned — the solvers re-encode it into bitsets.
+- **Format readers** (`formats/`) all take a `std::istream` and a filename and return an
+  `InputGraph`; `read_file_format` dispatches by name and can auto-detect. Supported: CSV, LAD,
+  directed/vertex-labelled/labelled LAD, DIMACS, and VFMCS.
+- **`SVOBitset`** (`innards/svo_bitset.hh`) is the small-vector-optimised bitset used everywhere for
+  domains and adjacency: inline storage for up to 16 64-bit words, heap beyond that.
+- **`loooong`** (`gss/loooong.hh`) is a thin GMP `mpz_t` wrapper for solution counts, which overflow
+  64 bits readily.
+- **`Watches`** (`innards/watches.hh`) is a generic two-watched-literal nogood store shared by the
+  homomorphism and clique searchers.
+- **`RestartsSchedule`** (`gss/restarts.hh`) and **`Timeout`** (`gss/timeout.hh`) are the search
+  control knobs. Restart policies: none, Luby, geometric, timed, and a thread-synchronised variant.
+- **`Proof`** (`innards/proof.{hh,cc}`) emits the VeriPB model (`.opb`) and proof log (`.pbp`).
+- **`Lackey`** (`innards/lackey.{hh,cc}`) talks to an external constraint solver over named pipes.
+- **`find_symmetries`** (`innards/symmetries.{hh,cc}`) shells out to the GAP computer algebra system
+  to find pattern/target symmetries.
+
+## Build and tests
+
+CMake with three presets — `release`, `debug`, and `sanitize` (ASan + UBSan) — see
+`CMakePresets.json`. The library and drivers need GMP; Catch2 and cxxopts are fetched via
+`FetchContent`. Unit tests live next to the code they cover (`gss/**/<name>_test.cc`, registered in
+`gss/CMakeLists.txt`) and run under `ctest`. Proof-verification tests (`src/CMakeLists.txt`,
+`test-instances/verify_proof.bash`) run the solver under VeriPB and are only registered when `veripb`
+is found. `run-tests.bash` is a small end-to-end smoke test over the binaries.

--- a/dev_docs/proof-logging.md
+++ b/dev_docs/proof-logging.md
@@ -1,0 +1,86 @@
+# Proof logging
+
+The solver can emit a machine-checkable certificate of its answer, verifiable with
+[VeriPB](https://gitlab.com/MIAOresearch/software/VeriPB). This document covers which option
+combinations are supported, how to run it, and the current known limitations. The encoding follows
+the constraint-programming-to-pseudo-Boolean approach from the project's papers (see the
+[README references](../README.md#references)); for the cleanup status of the open bugs see
+the [GitHub issues](https://github.com/ciaranm/glasgow-subgraph-solver/issues).
+
+## What it produces
+
+Passing `--prove NAME` writes two files:
+
+- `NAME.opb` — the pseudo-Boolean **model**: an OPB encoding of the problem instance (one set of
+  Boolean variables per CP variable, injectivity constraints, adjacency constraints, …).
+- `NAME.pbp` — the **proof log**: the sequence of VeriPB rules justifying every inference,
+  backtrack, and the final conclusion.
+
+You then check the pair with VeriPB:
+
+```shell session
+$ veripb NAME.opb NAME.pbp
+```
+
+Useful companion flags:
+
+- `--verbose-proofs` writes extra `*` comment lines into the log, for tracing.
+- `--recover-proof-encoding` emits the encoding in the form expected by verified (CakeML) encoders.
+
+## Supported option combinations (homomorphism / subgraph isomorphism)
+
+Proof logging for `glasgow_subgraph_solver` is currently incompatible with a number of the solver's
+"extra" features. Requesting `--prove` together with any of these throws an
+`UnsupportedConfiguration` (see `gss/homomorphism.cc`, the guard block near the top of
+`solve_homomorphism_problem`):
+
+| Requires | Because |
+| --- | --- |
+| a single thread (no `--parallel`, `--threads 1`) | proof logging is not thread-safe yet |
+| `--no-clique-detection` | the clique-detection shortcut is not yet logged |
+| no lackey (`--send-to-lackey` / `--receive-from-lackey`) | external propagation is not logged |
+| no less-than / occurs-less symmetry constraints | not yet logged |
+| injective or non-injective only (not `--locally-injective`) | only these two are encoded |
+| unlabelled graphs (no vertex or edge labels) | labels are not yet encoded |
+
+The README's worked example also passes `--no-supplementals` and `--no-nds`; that is the
+known-good combination this project tests against:
+
+```shell session
+$ ./build/glasgow_subgraph_solver --induced --no-supplementals --no-clique-detection --no-nds \
+    --prove myproof --format lad pattern target
+$ veripb myproof.opb myproof.pbp
+```
+
+Clique and maximum-common-subgraph proof logging also exist (`CliqueParams::proof_options`,
+`CommonSubgraphParams::proof_options`), and the common-subgraph reduction extends a clique proof
+internally.
+
+## Current status and known limitations
+
+- **Refutation (UNSAT) proofs verify.** Proving that *no* mapping exists works end to end with
+  VeriPB 3.0.2. The example above (an unsatisfiable induced instance) verifies
+  `s VERIFIED UNSATISFIABLE`.
+- **Solution (SAT) proofs do not currently verify.** There are two independent open bugs, both
+  tracked in the [GitHub issues](https://github.com/ciaranm/glasgow-subgraph-solver/issues):
+  1. The solver logs solutions with the VeriPB `solx` rule, which is the *enumeration* rule and
+     requires the OPB to declare a `preserved:` set of variables — which is not emitted. A plain
+     decision proof should use `sol` instead.
+  2. The adjacency-constraint encoding drops the loop→loop term, so a valid
+     loop-preserving solution falsifies the model.
+
+  These are "not yet implemented / to be fixed" issues, not fundamental restrictions, and are being
+  reworked in coordination with the verified CakeML encoder so the two encodings agree on loops and
+  solution logging.
+
+## Tests
+
+The `ctest` suite includes proof-verification tests (registered only when `veripb` is on the `PATH`):
+they run the solver with `--prove` on small instances and check the proof with VeriPB. The currently
+broken solution proofs are registered as `WILL_FAIL` tripwires, so the suite stays green while the
+bugs exist and will flag the moment they are fixed. See `src/CMakeLists.txt` and
+`test-instances/verify_proof.bash`.
+
+```shell session
+$ ctest --preset release -R proof
+```


### PR DESCRIPTION
## Summary

First **Phase 1 (documentation)** batch: two developer docs and a README fix.

- **`dev_docs/architecture.md`** — a navigable layer/dependency map (drivers → public API → `innards/` → formats/utils), what each major component does (the homomorphism model/searcher, clique and common-subgraph solvers, `InputGraph`, `SVOBitset`, `loooong`, `Watches`, restarts/timeout, proof, lackey, symmetries), and where the build and tests live.
- **`dev_docs/proof-logging.md`** — the under-documented part you flagged: the supported option-combination matrix for `--prove` (the `UnsupportedConfiguration` gates), how to run and check a proof, and an honest status section (refutation proofs verify; solution proofs are a tracked work-in-progress, with the two root-cause bugs cross-referenced).
- **`README.md`** — the proof-logging example used `--proof-solutions`, an option that was **removed** (so the documented command errors out). Replaced with a working refutation example (verified: `s VERIFIED UNSATISFIABLE`) and a pointer to the new doc.

No code changes; docs only.

Stacked on #45 (top of the test stack), so the cross-links to `cleanup-plan.md` resolve. Independent of the test content, so it can also be reviewed/merged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
