### PR TITLE
Remove raw allocations and tidy RAII

### DIFF
--- a/gss/clique.cc
+++ b/gss/clique.cc
@@ -86,15 +86,14 @@ namespace
 
         mt19937 global_rand;
 
-        int * space;
+        std::unique_ptr<int[]> space;
 
         CliqueRunner(const InputGraph & g, const CliqueParams & p) :
             params(p),
             size(g.size()),
             adj(g.size(), SVOBitset{unsigned(size), 0}),
             order(size),
-            invorder(size),
-            space(nullptr)
+            invorder(size)
         {
             if (p.proof_options)
                 proof = make_shared<Proof>(*p.proof_options);
@@ -115,7 +114,7 @@ namespace
                 proof->finalise_model();
             }
 
-            space = new int[size * (size + 1) * 2];
+            space = std::make_unique<int[]>(size * (size + 1) * 2);
 
             if (params.restarts_schedule->might_restart())
                 watches.table.data.resize(g.size());
@@ -143,11 +142,6 @@ namespace
                 for (int v = 0; v < size; ++v)
                     connected_table[v] = params.connected(order.at(v), [&](int x) { return invorder.at(x); });
             }
-        }
-
-        ~CliqueRunner()
-        {
-            delete[] space;
         }
 
         auto colour_class_order(

--- a/gss/formats/input_graph.cc
+++ b/gss/formats/input_graph.cc
@@ -53,7 +53,7 @@ struct InputGraph::Imp
 };
 
 InputGraph::InputGraph(int size, bool v, bool e) :
-    _imp(new Imp{})
+    _imp(std::make_unique<Imp>())
 {
     _imp->has_vertex_labels = v;
     _imp->has_edge_labels = e;

--- a/gss/innards/homomorphism_model.cc
+++ b/gss/innards/homomorphism_model.cc
@@ -148,7 +148,7 @@ struct HomomorphismModel::Imp
 
 HomomorphismModel::HomomorphismModel(const InputGraph & target, const InputGraph & pattern, const HomomorphismParams & params,
     const std::shared_ptr<Proof> & proof) :
-    _imp(new Imp(params, proof)),
+    _imp(make_unique<Imp>(params, proof)),
     max_graphs(calculate_n_shape_graphs(params)),
     pattern_size(pattern.size()),
     target_size(target.size())

--- a/gss/innards/lackey.cc
+++ b/gss/innards/lackey.cc
@@ -22,7 +22,7 @@ DisobedientLackeyError::DisobedientLackeyError(const std::string & m) noexcept :
 {
 }
 
-auto DisobedientLackeyError::what() const throw() -> const char *
+auto DisobedientLackeyError::what() const noexcept -> const char *
 {
     return _what.c_str();
 }

--- a/gss/innards/lackey.hh
+++ b/gss/innards/lackey.hh
@@ -19,7 +19,7 @@ namespace gss::innards
     public:
         explicit DisobedientLackeyError(const std::string & message) noexcept;
 
-        auto what() const throw() -> const char *;
+        auto what() const noexcept -> const char *;
     };
 
     class Lackey

--- a/gss/innards/proof.cc
+++ b/gss/innards/proof.cc
@@ -85,7 +85,7 @@ struct Proof::Imp
 };
 
 Proof::Proof(const ProofOptions & options) :
-    _imp(new Imp)
+    _imp(make_unique<Imp>())
 {
     _imp->opb_filename = options.opb_file;
     _imp->log_filename = options.log_file;

--- a/gss/innards/svo_bitset.cc
+++ b/gss/innards/svo_bitset.cc
@@ -15,8 +15,8 @@ SVOBitset::SVOBitset(unsigned size, unsigned bits)
             _data.short_data[i] = bits;
     }
     else {
-        _data.long_data = new BitWord[size];
-        for (unsigned i = 0; i < size; ++i)
+        _data.long_data = new BitWord[n_words];
+        for (unsigned i = 0; i < n_words; ++i)
             _data.long_data[i] = bits;
     }
 }

--- a/gss/innards/svo_bitset.hh
+++ b/gss/innards/svo_bitset.hh
@@ -14,11 +14,11 @@ namespace gss::innards
 {
 #ifdef USE_PORTABLE_SNIPPETS_BUILTIN
 #include <portable-snippets/builtin/builtin.h>
-    int popcount(unsigned long long x)
+    inline int popcount(unsigned long long x)
     {
         return psnip_builtin_popcountll(x);
     }
-    int countr_zero(unsigned long long x)
+    inline int countr_zero(unsigned long long x)
     {
         return psnip_builtin_ctzll(x);
     }


### PR DESCRIPTION
## Summary

First **Phase 3 (low-risk cleanup)** batch — removing raw allocations and tidying RAII. All behaviour-preserving.

- **clique workspace** — `CliqueRunner::space` becomes `std::unique_ptr<int[]>` instead of a raw `new int[]` / `delete[]` pair, so the manual destructor goes away.
- **pimpl constructors** — `make_unique<Imp>` instead of `new Imp` in `Proof`, `InputGraph`, and `HomomorphismModel`. `Lackey`'s is deliberately left: its aggregate initialiser with a `mutex` member makes `make_unique` impractical, and the `new` is immediately owned by the `unique_ptr` member anyway.
- **SVOBitset over-allocation** — the heap path allocated `size` words, but `size` is a *bit* count; it now allocates the `n_words` it actually uses (was ~64× too much). Caught while writing `svo_bitset_test`.
- **ODR hazard** — the `USE_PORTABLE_SNIPPETS_BUILTIN` `popcount`/`countr_zero` helpers are now `inline`.
- **deprecated spec** — `DisobedientLackeyError::what()` uses `noexcept` instead of the dynamic-exception-spec `throw()`.

## Test plan
- [x] `ctest --preset release` — 14/14 pass.
- [x] `ctest --preset sanitize` — 14/14 pass under ASan/UBSan (the allocation changes are the reason this lane matters).
- [x] `run-tests.bash` and a clique smoke test pass.

Note: I did **not** reformat `proof.cc` / `homomorphism_model.cc` despite a `clang-format` diff — that divergence pre-exists on `master` (clang-format version skew) and is unrelated to these one-line edits.

Stacked on #46. Each item is independent if you'd prefer to cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
