### PR TITLE
Fix the --shape option for subgraph isomorphism

### DIFF
--- a/gss/CMakeLists.txt
+++ b/gss/CMakeLists.txt
@@ -82,3 +82,7 @@ add_test(NAME common_subgraph_test COMMAND $<TARGET_FILE:common_subgraph_test>)
 add_executable(homomorphism_matrix_test homomorphism_matrix_test.cc)
 target_link_libraries(homomorphism_matrix_test PRIVATE glasgow_subgraphs Catch2::Catch2WithMain)
 add_test(NAME homomorphism_matrix_test COMMAND $<TARGET_FILE:homomorphism_matrix_test>)
+
+add_executable(extra_shapes_test extra_shapes_test.cc)
+target_link_libraries(extra_shapes_test PRIVATE glasgow_subgraphs Catch2::Catch2WithMain)
+add_test(NAME extra_shapes_test COMMAND $<TARGET_FILE:extra_shapes_test>)

--- a/gss/extra_shapes_test.cc
+++ b/gss/extra_shapes_test.cc
@@ -1,0 +1,68 @@
+#include <gss/formats/csv.hh>
+#include <gss/formats/input_graph.hh>
+#include <gss/homomorphism.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+#include <sstream>
+#include <utility>
+
+using namespace gss;
+
+using std::make_shared;
+using std::make_unique;
+using std::stringstream;
+
+using std::chrono::operator""s;
+
+namespace
+{
+    auto make_params() -> HomomorphismParams
+    {
+        HomomorphismParams params;
+        params.timeout = make_shared<Timeout>(0s);
+        params.restarts_schedule = make_unique<NoRestartsSchedule>();
+        params.count_solutions = true;
+        return params;
+    }
+
+    // An extra "shape" supplemental graph: a single edge whose endpoints are
+    // labelled "from" and "to". A supplemental edge between two graph vertices is
+    // added when the shape embeds between them, so this one tracks plain adjacency.
+    auto from_to_edge_shape() -> InputGraph
+    {
+        InputGraph shape{2, true, false};
+        shape.add_edge(0, 1);
+        shape.set_vertex_label(0, "from");
+        shape.set_vertex_label(1, "to");
+        return shape;
+    }
+}
+
+// Extra shapes are sound supplemental filters derived from the same instance, so
+// they prune the search but never change which mappings exist: the solution count
+// must be identical with and without them. (Before the CLI binding was fixed, the
+// --shape option was silently ignored; this guards the underlying feature.)
+TEST_CASE("an extra shape preserves the solution count")
+{
+    auto pattern = read_csv(stringstream{"a,b\nb,c\n"}, "p");     // path a-b-c
+    auto target = read_csv(stringstream{"1,2\n2,3\n3,4\n"}, "t"); // path 1-2-3-4
+
+    auto baseline = solve_homomorphism_problem(pattern, target, make_params()).solution_count;
+    CHECK(baseline > loooong{0}); // the instance is satisfiable, so the check below is meaningful
+
+    SECTION("injective, count 1")
+    {
+        auto params = make_params();
+        params.extra_shapes.emplace_back(make_unique<InputGraph>(from_to_edge_shape()), true, 1);
+        CHECK(solve_homomorphism_problem(pattern, target, params).solution_count == baseline);
+    }
+
+    SECTION("non-injective, count 2 exercises the other code paths")
+    {
+        auto params = make_params();
+        params.extra_shapes.emplace_back(make_unique<InputGraph>(from_to_edge_shape()), false, 2);
+        CHECK(solve_homomorphism_problem(pattern, target, params).solution_count == baseline);
+    }
+}

--- a/src/glasgow_subgraph_solver.cc
+++ b/src/glasgow_subgraph_solver.cc
@@ -120,9 +120,9 @@ auto main(int argc, char * argv[]) -> int
             ("decomposition", "Use decomposition")
             ("cliques", "Use clique size constraints")
             ("cliques-on-supplementals", "Use clique size constraints on supplemental graphs too")
-            ("shape", "Specify an extra shape graph (slow, experimental)", cxxopts::value<std::vector<std::string>>())
-            ("shape-count", "Specify how many times the shape must occur", cxxopts::value<std::vector<int>>())
-            ("shape-injective", "Specify whether the shape must occur injectively", cxxopts::value<std::vector<int>>());
+            ("shape", "Specify an extra shape graph (slow, experimental)", cxxopts::value<std::vector<std::string>>(shapes))
+            ("shape-count", "Specify how many times the shape must occur", cxxopts::value<std::vector<int>>(shape_counts))
+            ("shape-injective", "Specify whether the shape must occur injectively", cxxopts::value<std::vector<int>>(shape_injectives));
 
         options.add_options()
             ("pattern-file", "specify the pattern file", cxxopts::value<std::string>())


### PR DESCRIPTION
## Summary

Fixes the silently-broken `--shape` option on the subgraph isomorphism solver (a Phase 3 item).

`--shape`, `--shape-count`, and `--shape-injective` were declared with `cxxopts::value<...>()` but — unlike `--pattern-less-than`, which binds with `cxxopts::value<...>(pattern_less_thans)` — were **never bound** to the local `shapes` / `shape_counts` / `shape_injectives` vectors. Those vectors stayed empty, so the loop that fills `params.extra_shapes` never ran and the option did nothing. The fix binds the three options to their vectors; the supplemental-graph machinery (`HomomorphismModel::_build_extra_shape`) already supported the feature.

Per your steer, the option is correctly only on the subgraph isomorphism solver — the clique and common-subgraph drivers never had it.

## What an extra shape does

`_build_extra_shape` adds a supplemental filtering graph: for each vertex pair `(v, w)` it adds a supplemental edge iff the user's shape (a small graph with `from`/`to`-labelled endpoints) embeds between them. It's a **sound** filter derived from the same instance, so it only prunes the search — it never changes which mappings exist.

## Tests

- **`extra_shapes_test`** — exploits that soundness: an extra shape must leave the solution count unchanged. Checks count-invariance for an injective/count-1 shape and a non-injective/count-2 shape (which also exercises the count and non-injective code paths).
- **End to end** — with the fix, `--shape shape.csv` keeps the trident count at 12 and `supplemental_graph_names` now lists `extra_shape`; before, the option was silently ignored.

- [x] `ctest --preset release` — 15/15 pass.
- [x] `ctest --preset sanitize` — 15/15 pass under ASan/UBSan.

Stacked on #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
