### PR TITLE
Speed up CI: ccache and a prebuilt Catch2

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,13 +20,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Install GMP (Linux)
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ matrix.os }}-release
+
+    - name: Install dependencies (Linux)
       if: startsWith(matrix.os, 'ubuntu')
       run: sudo apt-get update && sudo apt-get install -y libgmp-dev
 
-    - name: Install GMP (macOS)
+    # On macOS, install Catch2 too: Homebrew ships a prebuilt bottle, so it does not
+    # have to be compiled from source (see find_package(Catch2) in CMakeLists.txt).
+    - name: Install dependencies (macOS)
       if: startsWith(matrix.os, 'macos')
-      run: brew install gmp
+      run: brew install gmp catch2
 
     - name: Fetch VeriPB
       run: git -c core.hooksPath=/dev/null clone --depth 1 https://gitlab.com/MIAOresearch/software/VeriPB.git
@@ -35,7 +42,10 @@ jobs:
       run: cargo install --path ./VeriPB
 
     - name: Configure CMake
-      run: cmake --preset release
+      run: |
+        EXTRA="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        if [[ "${{ matrix.os }}" == macos* ]]; then EXTRA="$EXTRA -DCMAKE_PREFIX_PATH=$(brew --prefix)"; fi
+        cmake --preset release $EXTRA
 
     - name: Build
       run: cmake --build --preset release
@@ -51,6 +61,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: sanitize
+
     - name: Install GMP
       run: sudo apt-get update && sudo apt-get install -y libgmp-dev
 
@@ -61,7 +76,7 @@ jobs:
       run: cargo install --path ./VeriPB
 
     - name: Configure CMake (Sanitize)
-      run: cmake --preset sanitize
+      run: cmake --preset sanitize -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build (Sanitize)
       run: cmake --build --preset sanitize

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,18 +78,26 @@ enable_testing()
 
 Include(FetchContent)
 Set(FETCHCONTENT_QUIET FALSE)
-FetchContent_Declare(
-        Catch2
-        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG 6e79e682b726f524310d55dec8ddac4e9c52fb5f # v3.4.0
-)
+
+# Prefer a prebuilt Catch2 (e.g. from Homebrew or apt) so it isn't compiled from
+# source on every build; fall back to fetching a pinned version otherwise. Catch2
+# v3 is a compiled library, so this is a worthwhile build-time saving (especially
+# on CI). Any v3 is fine -- the test macros are stable across minor versions.
+find_package(Catch2 3 QUIET)
+if(NOT Catch2_FOUND)
+    FetchContent_Declare(
+            Catch2
+            GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+            GIT_TAG 6e79e682b726f524310d55dec8ddac4e9c52fb5f # v3.4.0
+    )
+    FetchContent_MakeAvailable(Catch2)
+endif()
+
 FetchContent_Declare(
         cxxopts
         GIT_REPOSITORY https://github.com/jarro2783/cxxopts.git
         GIT_TAG 44380e5a44706ab7347f400698c703eb2a196202 # v3.3.1
 )
-
-FetchContent_MakeAvailable(Catch2)
 FetchContent_MakeAvailable(cxxopts)
 
 SET(CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,7 +57,7 @@ if(VERIPB_EXECUTABLE)
     # (2) enumeration: 'solx' requires a 'preserved:' set that GSS never emits.
     gss_add_known_broken_proof_test(proof_sat_loopless_count_KNOWN_BROKEN
         --count-solutions ${GSS_INSTANCES}/trident.csv ${GSS_INSTANCES}/longtrident.csv)
-    # (3) loop encoding: the self-loop->self-loop term is dropped from the adjacency
+    # (3) loop encoding: the loop->loop term is dropped from the adjacency
     #     constraint, so a valid loop-preserving solution falsifies the model.
     gss_add_known_broken_proof_test(proof_sat_loopy_decision_KNOWN_BROKEN
         --format lad ${GSS_INSTANCES}/small ${GSS_INSTANCES}/large)


### PR DESCRIPTION
## Summary

CI starts cold every run and rebuilds everything from source — including **Catch2 v3**, which (unlike v2) is a *compiled* library. This is the queued speed-up.

- **ccache** (`hendrikmuhs/ccache-action`) on both the `build` and `sanitize` jobs, with `-DCMAKE_CXX_COMPILER_LAUNCHER=ccache`. On a warm cache this skips recompiling everything unchanged — the solver, the 10 test binaries, *and* Catch2 (when it's still being fetched).
- **Prefer a prebuilt Catch2.** `CMakeLists.txt` now does `find_package(Catch2 3)` and only falls back to `FetchContent` if it isn't found. On **macOS** the workflow installs the **Homebrew bottle** (`brew install catch2`, a prebuilt binary — no source build) and passes `-DCMAKE_PREFIX_PATH=$(brew --prefix)` so CMake finds it. **Linux** keeps the pinned FetchContent build (now sped up by ccache). Accepting the system Catch2 on macOS is fine — the v3 test macros are stable across minor versions.
- Drive-by: fixes a stray `self-loop` in a `src/CMakeLists.txt` comment.

## Notes / what I couldn't test locally

- The `find_package(Catch2)` → FetchContent fallback is verified locally (no system Catch2 here → it fetches and builds; **15/15 tests pass**). The YAML validates and CMake accepts the `-D` flags.
- The ccache action, the Homebrew Catch2 path, and the `CMAKE_PREFIX_PATH` hint can only be exercised on the runners — **this PR's own CI run is the first real test** of them. The first run is a cold cache (populates it); the speed-up shows from the second run on. If `find_package(Catch2)` doesn't pick up the brew keg on a macOS lane, the fallback still builds it from source (correct, just not faster), so this can't break the build — worst case it's a no-op on that lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
