### PR TITLE
Bound the clique solver's workspace by the maximum degree (issue #39)

### DIFF
--- a/gss/clique.cc
+++ b/gss/clique.cc
@@ -24,6 +24,7 @@ using std::is_same;
 using std::list;
 using std::make_shared;
 using std::make_tuple;
+using std::max_element;
 using std::move;
 using std::mt19937;
 using std::pair;
@@ -114,8 +115,6 @@ namespace
                 proof->finalise_model();
             }
 
-            space = std::make_unique<int[]>(size * (size + 1) * 2);
-
             if (params.restarts_schedule->might_restart())
                 watches.table.data.resize(g.size());
 
@@ -126,6 +125,15 @@ namespace
             vector<int> degrees;
             degrees.resize(size);
             g.for_each_edge([&](int f, int t, string_view) { if (f != t) ++degrees[f]; });
+
+            // Workspace for the search: two int[size] arrays per recursion level. The
+            // search never recurses deeper than the largest clique, which is at most
+            // one more than the largest degree, so size the workspace to that rather
+            // than to the number of vertices (which would be quadratic in memory, and
+            // overflows an int product beyond ~32k vertices -- issue #39). size_t
+            // arithmetic keeps it correct for dense graphs where the degree is large.
+            int max_degree = degrees.empty() ? 0 : *max_element(degrees.begin(), degrees.end());
+            space = std::make_unique<int[]>(std::size_t(2) * size * (max_degree + 2));
 
             // sort on degree
             if (! params.input_order)

--- a/gss/clique_test.cc
+++ b/gss/clique_test.cc
@@ -162,6 +162,22 @@ TEST_CASE("the colour orderings and vertex order all find the same maximum")
     }
 }
 
+TEST_CASE("a large sparse graph does not overflow the workspace (issue #39)")
+{
+    // Beyond ~32768 vertices the old size*(size+1)*2 workspace size overflowed a
+    // signed int. This graph has a single 5-clique and is otherwise empty, so the
+    // search is trivial -- the point is that the solver is set up at all, with the
+    // workspace now bounded by the largest degree rather than the vertex count.
+    const int n = 33000;
+    InputGraph g{n, false, false};
+    for (int i = 0; i < 5; ++i)
+        for (int j = i + 1; j < 5; ++j)
+            g.add_edge(i, j);
+
+    auto result = solve_clique_problem(g, make_params());
+    CHECK(result.clique == set<int>{0, 1, 2, 3, 4});
+}
+
 // ---------------------------------------------------------------------------
 // Loops (irrelevant to cliques; previously a crash, see issue #38)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses the crashes in #39 (`std::bad_alloc` / `std::bad_array_new_length` on large graphs).

Both reports — james's direct clique solve (46,656 vertices) and alabarre's via clique detection (K₃ pattern → clique solve on a 33,696-vertex target) — hit the same line:

```cpp
space = std::make_unique<int[]>(size * (size + 1) * 2);
```

Two problems:
1. **Integer overflow.** `size` is `int`, so `size*(size+1)*2` overflows beyond ~32,768 vertices. Depending on how the UB resolves it's either a negative length (`bad_array_new_length`, alabarre's `33696`) or, kept as the true value at `-O3`, a ~17 GB `bad_alloc` (james's `46656`).
2. **It's O(V²) anyway** — `8·V²` bytes, **64× the adjacency matrix** (17 GB for 46,656 vertices), so even fixing the overflow just yields an honest huge allocation.

## Fix

The search never recurses deeper than the largest clique, which is at most `max_degree + 1` (every clique member needs ≥ k−1 neighbours). So the workspace is sized to `2·size·(max_degree + 2)` in `size_t`. For sparse graphs that's tiny; for dense graphs `max_degree ≈ V`, so it's unchanged and still correct.

- A **33,000-vertex, ω=5** graph now solves in 0.03 s using ~150 MB (just the adjacency matrix) instead of crashing.
- This does **not** remove the adjacency matrix's own O(V²) cost, which remains the real limit on input size — so I've left #39 open rather than auto-closing.

## Depth bound — verified empirically

Instrumented the recursion (temporarily) on "every vertex adjacent to all but one" (cocktail-party) graphs and a complete graph:

| graph | Δ | ω | max recursion depth |
|---|---|---|---|
| cocktail-party 20/100/400 vtx | 18/98/398 | 10/50/200 | 9 / 49 / 199 (= ω−1) |
| complete K₁₀₀ | 99 | 100 | 0 (the residual is already a clique → short-circuit, no recursion) |

Depth tops out at ω−1 ≤ Δ, so the `max_degree+2` workspace always has headroom, and the dense graphs run ASan-clean.

Adds a regression test on a 33,000-vertex sparse graph (past the old overflow threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
