### PR TITLE
Randomised correctness + proof sweeps; revert blocking-constraint deletion

### DIFF
--- a/dev_docs/proof-logging.md
+++ b/dev_docs/proof-logging.md
@@ -90,8 +90,14 @@ the solution count sound. VeriPB checks the claimed count `<n>` against the numb
   `s VERIFIED {COMPLETE,PARTIAL} ENUMERATION OF n SOLUTIONS`. The adjacency constraint keeps the
   target self-loop term in its neighbour sum, so a loop→loop solution satisfies the model (this was
   [issue #49], now fixed).
+- **Enumeration proof size is linear in the number of solutions.** Each solution's `solx` blocking
+  constraint is kept at the top proof level for the rest of the proof. Deleting them on backtrack to
+  keep the proof linear in the search depth (by moving the subsuming backtrack nogoods into the core)
+  was tried, but `core id`-ing those nogoods triggered an upstream VeriPB bug that made later steps
+  fail to verify, so it was reverted. See [issue #59] for the tracking issue and how to re-enable it.
 
 [issue #49]: https://github.com/ciaranm/glasgow-subgraph-solver/issues/49
+[issue #59]: https://github.com/ciaranm/glasgow-subgraph-solver/issues/59
 
 ## Verifying with the CakePB checker
 

--- a/gss/CMakeLists.txt
+++ b/gss/CMakeLists.txt
@@ -83,6 +83,10 @@ add_executable(homomorphism_matrix_test homomorphism_matrix_test.cc)
 target_link_libraries(homomorphism_matrix_test PRIVATE glasgow_subgraphs Catch2::Catch2WithMain)
 add_test(NAME homomorphism_matrix_test COMMAND $<TARGET_FILE:homomorphism_matrix_test>)
 
+add_executable(random_homomorphism_test random_homomorphism_test.cc)
+target_link_libraries(random_homomorphism_test PRIVATE glasgow_subgraphs Catch2::Catch2WithMain)
+add_test(NAME random_homomorphism_test COMMAND $<TARGET_FILE:random_homomorphism_test>)
+
 add_executable(extra_shapes_test extra_shapes_test.cc)
 target_link_libraries(extra_shapes_test PRIVATE glasgow_subgraphs Catch2::Catch2WithMain)
 add_test(NAME extra_shapes_test COMMAND $<TARGET_FILE:extra_shapes_test>)

--- a/gss/homomorphism.cc
+++ b/gss/homomorphism.cc
@@ -498,11 +498,6 @@ auto gss::solve_homomorphism_problem(
         // solution count is in terms of the high-level mapping
         proof->emit_preserved_assignment_variables();
 
-        // when counting, delete each solution-blocking constraint once we backtrack
-        // past it, so the proof stays linear in the search depth not the solution count
-        if (params.count_solutions)
-            proof->delete_blocking_constraints_on_backtrack();
-
         // output the model file
         proof->finalise_model();
     }

--- a/gss/innards/proof.cc
+++ b/gss/innards/proof.cc
@@ -72,15 +72,6 @@ struct Proof::Imp
     int largest_level_set = 0;
     int active_level = 0;
 
-    // For counting / enumeration: solution-blocking constraints (and the backtrack
-    // nogoods that justify deleting them) accumulate, which is exponentially
-    // expensive when there are many solutions. When this is set, we move each
-    // backtrack nogood into the core and, on backtracking out of a level, checked-
-    // delete the blocking constraints and now-subsumed core nogoods recorded at that
-    // level. Keyed by the proof level the line was created at.
-    bool manage_blocking_constraints = false;
-    map<int, vector<long>> deletable_core_lines_by_level;
-
     bool clique_encoding = false;
     bool doing_mcs_by_clique = false;
 
@@ -192,11 +183,6 @@ auto Proof::emit_preserved_assignment_variables() -> void
     for (auto & [_, name] : _imp->variable_mappings)
         _imp->model_prelude_stream << " x" << name;
     _imp->model_prelude_stream << " ;\n";
-}
-
-auto Proof::delete_blocking_constraints_on_backtrack() -> void
-{
-    _imp->manage_blocking_constraints = true;
 }
 
 auto Proof::finalise_model() -> void
@@ -480,14 +466,6 @@ auto Proof::incorrect_guess(const vector<pair<int, int>> & decisions, bool failu
         *_imp->proof_stream << " 1 ~x" << _imp->variable_mappings[pair{var, val}];
     *_imp->proof_stream << " >= 1 ;\n";
     ++_imp->proof_line;
-
-    // when managing blocking constraints, this backtrack nogood justifies deleting
-    // the blocking constraints (and deeper, now-subsumed, nogoods) below it, so it
-    // has to live in the core; it is itself deleted when we backtrack past its level
-    if (_imp->manage_blocking_constraints) {
-        *_imp->proof_stream << "core id " << _imp->proof_line << " ;\n";
-        _imp->deletable_core_lines_by_level[_imp->active_level].push_back(_imp->proof_line);
-    }
 }
 
 auto Proof::out_of_guesses(const vector<pair<int, int>> &) -> void
@@ -515,22 +493,6 @@ auto Proof::back_up_to_level(int l) -> void
 
 auto Proof::forget_level(int l) -> void
 {
-    // checked-delete the blocking constraints and core nogoods recorded at this
-    // level or deeper: the backtrack nogood just emitted (one level up, now in the
-    // core) subsumes them, so each deletion re-derives by RUP. This is what keeps
-    // a counting proof linear in the search depth rather than the solution count.
-    if (_imp->manage_blocking_constraints) {
-        for (auto it = _imp->deletable_core_lines_by_level.begin(); it != _imp->deletable_core_lines_by_level.end();) {
-            if (it->first >= l) {
-                for (auto & id : it->second)
-                    *_imp->proof_stream << "del id " << id << " ;\n";
-                it = _imp->deletable_core_lines_by_level.erase(it);
-            }
-            else
-                ++it;
-        }
-    }
-
     if (_imp->largest_level_set >= l)
         *_imp->proof_stream << "wiplvl " << l << ";\n";
 }
@@ -571,11 +533,6 @@ auto Proof::post_solution(const vector<pair<NamedVertex, NamedVertex>> & decisio
         *_imp->proof_stream << " x" << _imp->variable_mappings[pair{var.first, val.first}];
     *_imp->proof_stream << ";\n";
     ++_imp->proof_line;
-
-    // remember to checked-delete this blocking constraint once we backtrack out
-    // of the level it was found at (it is then subsumed by a backtrack nogood)
-    if (_imp->manage_blocking_constraints)
-        _imp->deletable_core_lines_by_level[_imp->active_level].push_back(_imp->proof_line);
 
     if (0 != _imp->active_level)
         *_imp->proof_stream << "setlvl " << _imp->active_level << ";\n";

--- a/gss/innards/proof.hh
+++ b/gss/innards/proof.hh
@@ -69,11 +69,6 @@ namespace gss::innards
         // after all create_cp_variable calls but before finalise_model.
         auto emit_preserved_assignment_variables() -> void;
 
-        // Enable checked deletion of solution-blocking constraints on backtrack,
-        // keeping enumeration proofs to a size linear in the search depth rather
-        // than the number of solutions. Only sound (and only needed) when counting.
-        auto delete_blocking_constraints_on_backtrack() -> void;
-
         auto finalise_model() -> void;
 
         // when we're done

--- a/gss/random_homomorphism_test.cc
+++ b/gss/random_homomorphism_test.cc
@@ -1,0 +1,145 @@
+#include <gss/formats/input_graph.hh>
+#include <gss/homomorphism.hh>
+#include <gss/innards/verify.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <random>
+#include <set>
+#include <vector>
+
+using namespace gss;
+using namespace gss::innards;
+
+using std::make_shared;
+using std::make_unique;
+using std::map;
+using std::mt19937;
+using std::set;
+using std::uniform_real_distribution;
+using std::vector;
+
+using std::chrono::operator""s;
+
+namespace
+{
+    // A random undirected graph with optional self-loops. (add_edge is symmetric, so
+    // there is no directed-graph API to drive here; directed instances are left for a
+    // future extension.)
+    auto random_graph(int n, double edge_probability, double loop_probability, mt19937 & rng) -> InputGraph
+    {
+        InputGraph g{n, false, false};
+        uniform_real_distribution<double> dist{0.0, 1.0};
+        for (int v = 0; v < n; ++v) {
+            if (dist(rng) < loop_probability)
+                g.add_edge(v, v);
+            for (int w = v + 1; w < n; ++w)
+                if (dist(rng) < edge_probability)
+                    g.add_edge(v, w);
+        }
+        return g;
+    }
+
+    // The brute-force oracle: every complete mapping pattern -> target that the
+    // solver's own verifier accepts. verify_homomorphism does no search, so this is
+    // an independent specification of "what counts as a solution" for these options.
+    auto brute_force_solutions(const InputGraph & pattern, const InputGraph & target,
+        bool injective, bool locally_injective, bool induced) -> set<map<int, int>>
+    {
+        set<map<int, int>> solutions;
+        int np = pattern.size(), nt = target.size();
+        if (np == 0 || nt == 0)
+            return solutions;
+
+        // iterate over all nt^np functions as a mixed-radix counter
+        vector<int> assignment(np, 0);
+        for (;;) {
+            map<int, int> mapping;
+            for (int i = 0; i < np; ++i)
+                mapping.emplace(i, assignment[i]);
+
+            try {
+                verify_homomorphism(pattern, target, injective, locally_injective, induced, mapping);
+                solutions.insert(move(mapping));
+            }
+            catch (const BuggySolution &) {
+                // not a valid mapping for these options
+            }
+
+            int i = 0;
+            for (; i < np; ++i) {
+                if (++assignment[i] < nt)
+                    break;
+                assignment[i] = 0;
+            }
+            if (i == np)
+                break;
+        }
+
+        return solutions;
+    }
+}
+
+TEST_CASE("random instances: solver enumeration matches the brute-force oracle")
+{
+    // Fixed seed so failures reproduce; the iteration index identifies the instance.
+    mt19937 rng{0x5eed};
+
+    for (int iter = 0; iter < 1500; ++iter) {
+        int np = 1 + int(rng() % 4); // 1..4
+        int nt = 1 + int(rng() % 5); // 1..5
+        double pattern_density = (rng() % 100) / 100.0;
+        double target_density = (rng() % 100) / 100.0;
+        double loop_probability = (rng() % 3 == 0) ? 0.25 : 0.0;
+
+        auto pattern = random_graph(np, pattern_density, loop_probability, rng);
+        auto target = random_graph(nt, target_density, loop_probability, rng);
+
+        bool induced = (rng() % 2);
+        // Injective and non-injective only: locally-injective enumeration is currently
+        // wrong (over-prunes), tracked as issue #58 -- re-enable that arm once it's fixed.
+        int injectivity_choice = rng() % 2;
+        auto injectivity = injectivity_choice == 0 ? Injectivity::Injective : Injectivity::NonInjective;
+        bool injective = (injectivity == Injectivity::Injective);
+        bool locally_injective = false;
+
+        auto expected = brute_force_solutions(pattern, target, injective, locally_injective, induced);
+
+        HomomorphismParams params;
+        params.timeout = make_shared<Timeout>(0s);
+        params.restarts_schedule = make_unique<NoRestartsSchedule>();
+        params.injectivity = injectivity;
+        params.induced = induced;
+        params.count_solutions = true;
+
+        set<map<int, int>> got;
+        params.enumerate_callback = [&](const VertexToVertexMapping & mapping) {
+            got.insert(mapping);
+            return true;
+        };
+
+        auto result = solve_homomorphism_problem(pattern, target, params);
+
+        auto edges = [](const InputGraph & g) {
+            std::string s;
+            for (int a = 0; a < g.size(); ++a)
+                for (int b = a; b < g.size(); ++b)
+                    if (g.adjacent(a, b))
+                        s += " " + std::to_string(a) + "-" + std::to_string(b);
+            return s;
+        };
+        INFO("iteration " << iter << ", |pattern|=" << np << ", |target|=" << nt
+                          << ", induced=" << induced << ", injectivity=" << injectivity_choice
+                          << "\n  pattern edges:" << edges(pattern)
+                          << "\n  target edges:" << edges(target)
+                          << "\n  solver=" << got.size() << " oracle=" << expected.size());
+        CHECK(got == expected);
+        CHECK(result.solution_count == int(expected.size()));
+        // a non-empty enumeration must have run to completion; the only incomplete
+        // case is the trivial injective pattern-bigger-than-target shortcut (0 solutions)
+        CHECK((result.complete || expected.empty()));
+    }
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,6 +102,15 @@ if(VERIPB_EXECUTABLE)
     gss_add_proof_test(proof_mcs_clique glasgow_common_subgraph_solver --clique
         ${GSS_INSTANCES}/small ${GSS_INSTANCES}/large)
 
+    # Randomised proof sweep: generate random instances and check the proof verifies
+    # on each, across decision/induced/counting combinations. Catches proof-logging
+    # bugs that fixed instances miss; complements the in-process correctness oracle in
+    # random_homomorphism_test.
+    add_test(NAME proof_random_sweep
+        COMMAND ${CMAKE_SOURCE_DIR}/test-instances/random_proof_sweep.bash
+            $<TARGET_FILE:glasgow_subgraph_solver> ${VERIPB_EXECUTABLE}
+            $<TARGET_FILE:create_random_graph> ${CMAKE_CURRENT_BINARY_DIR})
+
     # End-to-end verified-pipeline tests through the CakePB checker. Only registered
     # when cake_pb_iso was found (see CAKE_PB_ISO_EXECUTABLE in the top-level
     # CMakeLists); a checkout without it just skips these. The pipeline checks the

--- a/test-instances/random_proof_sweep.bash
+++ b/test-instances/random_proof_sweep.bash
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Generate random instances and check that the solver's proof verifies on each,
+# across a spread of graph structures and option combinations. This catches
+# proof-logging bugs that the fixed instances miss -- a derivation that only breaks
+# on certain structures (e.g. issue #56 would have shown up here). Correctness of
+# the *counts* is checked separately and in-process by random_homomorphism_test.
+#
+# Deterministic: create_random_graph is seeded and the solver is run without
+# restarts, so every proof is reproducible.
+#
+# Usage:
+#   random_proof_sweep.bash <solver> <veripb> <create_random_graph> <workdir>
+#
+# Exits 0 iff every generated proof verifies.
+
+set -u
+
+if [ "$#" -ne 4 ]; then
+    echo "usage: $0 <solver> <veripb> <create_random_graph> <workdir>" 1>&2
+    exit 2
+fi
+
+solver="$1"
+veripb="$2"
+crg="$3"
+workdir="$4"
+
+fails=0
+checked=0
+
+# loopless random graphs (no --loops): supplemental graphs are on by default, so the
+# exact-path / distance derivations get exercised; loops + supplementals is issue #56.
+for seed in $(seq 1 8); do
+    pat="${workdir}/rps_pattern_${seed}.csv"
+    tgt="${workdir}/rps_target_${seed}.csv"
+    "${crg}" --seed "${seed}" 5 0.5 > "${pat}"
+    "${crg}" --seed "$((seed + 100))" 8 0.45 > "${tgt}"
+
+    for opts in "" "--induced" "--count-solutions" "--induced --count-solutions"; do
+        checked=$((checked + 1))
+        proof="${workdir}/rps_proof_${seed}_${checked}"
+
+        # shellcheck disable=SC2086
+        if ! "${solver}" --format csv --no-clique-detection ${opts} --prove "${proof}" \
+                "${pat}" "${tgt}" > "${proof}.log" 2>&1; then
+            echo "seed ${seed}, opts '${opts}': solver failed" 1>&2
+            cat "${proof}.log" 1>&2
+            fails=$((fails + 1))
+            continue
+        fi
+
+        if ! "${veripb}" "${proof}.opb" "${proof}.pbp" 2>&1 | grep -q 'VERIFIED'; then
+            echo "seed ${seed}, opts '${opts}': proof did NOT verify" 1>&2
+            "${veripb}" "${proof}.opb" "${proof}.pbp" 2>&1 | tail -4 1>&2
+            fails=$((fails + 1))
+        fi
+    done
+done
+
+echo "checked ${checked} random proofs, ${fails} failure(s)"
+[ "${fails}" -eq 0 ]


### PR DESCRIPTION
Adds randomised testing for the solver's enumeration and proofs (the other half of the
pre-refactor safety net), and reverts the enumeration blocking-constraint deletion after the proof
sweep found it produces proofs that don't verify.

## Randomised tests

- **`random_homomorphism_test`** — generates random small graphs and option combinations and checks
  the solver's enumeration against a brute-force oracle (every complete mapping `verify_homomorphism`
  accepts — the solver's own search-free checker, used as an independent spec). 1500 instances/run,
  deterministic. It found that **locally-injective enumeration over-prunes** (issue #58), so the sweep
  covers injective + non-injective for now.
- **`random_proof_sweep.bash`** — generates random instances and checks the solver's proof verifies on
  each (decision / induced / counting). Catches proof-logging bugs the fixed instances miss; registered
  only when VeriPB is available.

## Revert: blocking-constraint deletion

The proof sweep found that the enumeration blocking-constraint deletion (which moved backtrack nogoods
into the core via `core id` so the solution-blocking constraints could be checked-deleted on backtrack)
produces proofs that **don't verify** on some instances. Reduced to a minimal reproducer: adding two
`core id` statements to an otherwise-verifying proof makes a later `rup` fail — a monotonicity
violation, since RUP propagates over core ∪ derived either way. **This is a VeriPB bug, reported
upstream.**

Reverted to logging `solx` at the top level and keeping the blocking constraints. Enumeration proofs
verify robustly again, at the cost of size linear in the number of solutions (was the original concern;
reducing it properly via extension-variable tabulation is future work). Tracked in issue #59.

36/36 ctest, clean under ASan/UBSan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)