### PR TITLE
Proof logging for loops with supplemental graphs (#56)

### DIFF
--- a/dev_docs/proof-logging.md
+++ b/dev_docs/proof-logging.md
@@ -46,14 +46,23 @@ Proof logging for `glasgow_subgraph_solver` is currently incompatible with a num
 | no less-than / occurs-less symmetry constraints | not yet logged |
 | injective or non-injective only (not `--locally-injective`) | only these two are encoded |
 | unlabelled graphs (no vertex or edge labels) | labels are not yet encoded |
-| no supplemental graphs **on loopy instances** (`--no-supplementals`) | the supplemental-graph derivations don't yet handle the self-loop term ([issue #56]) |
+
+Supplemental graphs, distance-3 (`--distance3`), neighbourhood degree sequences, and clique-size
+constraints (`--cliques`) are supported with proof logging, on both loopless and loopy instances.
+
+Loops used to be incompatible with supplemental graphs ([issue #56], now fixed). The adjacency
+constraint keeps the target's self-loop term (so a loop→loop mapping satisfies the model, see
+[issue #49]), but that term is a stray when the constraint is summed into a pseudo-Boolean
+derivation. So before any such derivation, `Proof::loop_fix_adjacencies` derives the loop-cancelled
+form of each loop-bearing adjacency constraint — `~x_p_t` together with the neighbours of `t` other
+than `t` itself, which follows from the constraint plus injectivity on `t` — and the degree,
+supplemental-graph and distance-3 pols sum *that* in its place. The induced encoding additionally
+forbids a non-loopy pattern vertex from mapping to a loopy target (the `q == p` case of induced
+non-edge preservation), which the model previously left out.
 
 [issue #56]: https://github.com/ciaranm/glasgow-subgraph-solver/issues/56
 
-Supplemental graphs, distance-3 (`--distance3`), neighbourhood degree sequences, and clique-size
-constraints (`--cliques`) *are* supported with proof logging on loopless instances. The one
-exception is supplemental graphs together with loops, which is guarded off (issue #56) and is a
-priority to fix. A minimal worked example:
+A minimal worked example:
 
 ```shell session
 $ ./build/glasgow_subgraph_solver --induced --no-supplementals --no-clique-detection --no-nds \

--- a/gss/homomorphism.cc
+++ b/gss/homomorphism.cc
@@ -429,11 +429,6 @@ auto gss::solve_homomorphism_problem(
             throw UnsupportedConfiguration{"Proof logging cannot yet be used on labelled graphs"};
         if (params.count_solutions && params.restarts_schedule && params.restarts_schedule->might_restart())
             throw UnsupportedConfiguration{"Proof logging cannot yet be used when counting with restarts, use --restarts none"};
-        if ((pattern.loopy() || target.loopy()) && ! params.no_supplementals)
-            // the supplemental-graph proof derivations sum adjacency constraints assuming a
-            // loopless encoding, so they do not verify once a self-loop term is present
-            // (issue #56); refuse rather than emit an invalid proof
-            throw UnsupportedConfiguration{"Proof logging cannot yet be used on graphs with loops together with supplemental graphs, use --no-supplementals"};
 
         proof = make_shared<Proof>(*params.proof_options);
 
@@ -490,6 +485,25 @@ auto gss::solve_homomorphism_problem(
                                 NamedVertex{t, target.vertex_name(t)},
                                 permitted, true);
                         }
+
+                    // the q == p case of non-edge preservation: a non-loopy pattern
+                    // vertex cannot map to a loopy target, since induced isomorphism
+                    // requires loop(p) == loop(t). The loop above skips q == p, and the
+                    // edge loop only constrains a loopy p, so without this the model
+                    // admits invalid induced mappings (issue #56). p -> t then forces p
+                    // onto a non-neighbour of t; with t a neighbour of itself and
+                    // at-most-one-value, that is a contradiction.
+                    if (! pattern.adjacent(p, p) && target.adjacent(t, t)) {
+                        vector<int> permitted;
+                        for (int u = 0; u < target.size(); ++u)
+                            if (! target.adjacent(t, u))
+                                permitted.push_back(u);
+                        proof->create_adjacency_constraint(
+                            NamedVertex{p, pattern.vertex_name(p)},
+                            NamedVertex{p, pattern.vertex_name(p)},
+                            NamedVertex{t, target.vertex_name(t)},
+                            permitted, true);
+                    }
                 }
             }
         }
@@ -500,6 +514,11 @@ auto gss::solve_homomorphism_problem(
 
         // output the model file
         proof->finalise_model();
+
+        // derive the loop-cancelled form of each loopy adjacency constraint, so the
+        // degree, supplemental-graph and distance-3 derivations can sum them into pols
+        // without a stray "maps to the loopy target" term (issue #56).
+        proof->loop_fix_adjacencies();
     }
 
     // first sanity check: if we're finding an injective mapping, and there

--- a/gss/innards/homomorphism_model.cc
+++ b/gss/innards/homomorphism_model.cc
@@ -734,6 +734,20 @@ auto HomomorphismModel::prepare() -> bool
 
     _imp->supplemental_graph_names.push_back("original");
 
+    // Emit every loop-based incompatibility up front, as a unit clause. The target graph
+    // rows have self-loops stripped, so the adjacency, supplemental-graph and degree
+    // derivations all carry stray "maps to a loopy vertex" terms; having ~x_p_t available
+    // as a unit lets unit propagation (and the search-failure rups) discharge them. This
+    // also covers the induced loop-mismatch case, which otherwise prunes p->t silently
+    // without a proof line (issue #56).
+    if (_imp->proof) {
+        for (unsigned p = 0; p < pattern_size; ++p)
+            for (unsigned t = 0; t < target_size; ++t)
+                if ((pattern_has_loop(p) && ! target_has_loop(t)) ||
+                    (_imp->params.induced && (pattern_has_loop(p) != target_has_loop(t))))
+                    _imp->proof->incompatible_by_loops(pattern_vertex_for_proof(p), target_vertex_for_proof(t));
+    }
+
     // pattern and target degrees, for the main graph
     _imp->patterns_degrees.at(0).resize(pattern_size);
     _imp->targets_degrees.at(0).resize(target_size);

--- a/gss/innards/proof.cc
+++ b/gss/innards/proof.cc
@@ -60,6 +60,7 @@ struct Proof::Imp
     map<tuple<long, long, long, long>, string> connected_variable_mappings_aux;
     map<long, string> at_least_one_value_constraints, at_most_one_value_constraints, injectivity_constraints;
     map<tuple<long, long, long, long>, string> adjacency_lines;
+    map<tuple<long, long, long, long>, vector<long>> adjacency_permitted;
     map<pair<long, long>, long> eliminations;
     map<pair<long, long>, string> non_edge_constraints;
     long objective_line = 0;
@@ -171,6 +172,43 @@ auto Proof::create_adjacency_constraint(const NamedVertex & p, const NamedVertex
     _imp->model_stream << " >= 1 ;\n";
     ++_imp->nb_constraints;
     _imp->adjacency_lines.emplace(tuple{0, p.first, q.first, t.first}, adj_label);
+    _imp->adjacency_permitted.emplace(tuple{0, p.first, q.first, t.first}, vector<long>(uu.begin(), uu.end()));
+}
+
+auto Proof::loop_fix_adjacencies() -> void
+{
+    // Before issue #49 the adjacency constraint left the target's self-loop term out, so
+    // it could be summed into a pol cleanly. We now keep that term (so a loop->loop
+    // mapping satisfies the model), but it then appears as a stray "q maps to the loopy
+    // target" term in every pol. For each adjacency constraint over a loopy target t,
+    // rewrite its @adj label here to the loop-cancelled version -- ~x_p_t together with
+    // the neighbours of t other than t -- which follows from the constraint plus
+    // injectivity on t (mapping p to t forbids q from also mapping to t). VeriPB lets a
+    // proof line reassign an existing label, so every later reference to @adj in a pol
+    // picks up the loop-cancelled form automatically; the original loop-bearing
+    // constraint stays in the database (by number) so solutions still satisfy the model.
+    for (auto & [key, label] : _imp->adjacency_lines) {
+        auto & [g, p, q, t] = key;
+        // a pattern self-loop edge (p == q) has its loop term pinned by at-most-one rather
+        // than injectivity, and is not summed into the supplemental/degree pols; skip it.
+        if (p == q)
+            continue;
+        auto pit = _imp->adjacency_permitted.find(key);
+        if (pit == _imp->adjacency_permitted.end())
+            continue;
+        if (find(pit->second.begin(), pit->second.end(), t) == pit->second.end())
+            continue; // t is not a neighbour of itself: no loop term to cancel
+        *_imp->proof_stream << label << " rup 1 ~x" << _imp->variable_mappings[pair{p, t}];
+        for (auto & u : pit->second)
+            if (u != t)
+                *_imp->proof_stream << " 1 x" << _imp->variable_mappings[pair{q, u}];
+        *_imp->proof_stream << " >= 1 ;\n";
+        ++_imp->proof_line;
+        // (The original loop-bearing constraint is now redundant, but it is left in place:
+        // deleting it needs `del id <number>`, and that number does not correspond to the
+        // same constraint in CakePB's independently-numbered OPB, so the deletion breaks
+        // the verified-pipeline elaboration. The extra constraint is cheap.)
+    }
 }
 
 auto Proof::emit_preserved_assignment_variables() -> void
@@ -398,9 +436,13 @@ auto Proof::incompatible_by_loops(
     const NamedVertex & p,
     const NamedVertex & t) -> void
 {
+    // may be requested both up front (so the unit is available to later derivations and
+    // search propagations) and again during domain initialisation: only emit it once.
+    if (_imp->eliminations.contains(pair{p.first, t.first}))
+        return;
     *_imp->proof_stream << "% cannot map " << p.second << " to " << t.second << " due to loop\n";
     *_imp->proof_stream << "rup 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}] << " >= 1 ;\n";
-    ++_imp->proof_line;
+    _imp->eliminations.emplace(pair{p.first, t.first}, ++_imp->proof_line);
 }
 
 auto Proof::initial_domain_is_empty(int p, const string & where) -> void
@@ -610,16 +652,17 @@ auto Proof::create_exact_path_graphs(
     for (auto & b : between_p_and_q) {
         for (auto & w : n_t) {
             // due to loops or labels, it might not be possible to map to w
-            auto i = _imp->adjacency_lines.find(tuple{0, b.first, q.first, w.first});
-            if (i != _imp->adjacency_lines.end())
-                *_imp->proof_stream << " " << i->second << " +";
+            if (_imp->adjacency_lines.contains(tuple{0, b.first, q.first, w.first}))
+                *_imp->proof_stream << " " << _imp->adjacency_lines.at(tuple{0, b.first, q.first, w.first}) << " +";
         }
     }
 
     *_imp->proof_stream << " s ;\n";
     ++_imp->proof_line;
 
-    // first tidy-up step: if p maps to t then q maps to something a two-walk away from t
+    // first tidy-up step: if p maps to t then q maps to something a two-walk away from t.
+    // The adjacency constraints summed above are the loop-cancelled forms, so there is no
+    // stray loop term and plain implication addition closes it.
     *_imp->proof_stream << "ia 1 ~x" << _imp->variable_mappings[pair{p.first, t.first}];
     for (auto & u : two_away_from_t)
         *_imp->proof_stream << " 1 x" << _imp->variable_mappings[pair{q.first, u.first.first}];

--- a/gss/innards/proof.hh
+++ b/gss/innards/proof.hh
@@ -63,6 +63,12 @@ namespace gss::innards
         auto create_adjacency_constraint(const NamedVertex & p, const NamedVertex & q, const NamedVertex & t,
             const std::vector<int> & u, bool induced) -> void;
 
+        // For every adjacency constraint over a loopy target, derive its loop-cancelled
+        // form (the pre-#49 encoding) once, so that derivations can sum it into a pol
+        // without dragging in the stray "maps to the loopy target" term. Must be called
+        // after finalise_model and before any derivation that sums adjacency constraints.
+        auto loop_fix_adjacencies() -> void;
+
         // Declare a projected (preserved) set, listing exactly the assignment
         // variables, so the proof's solution count is in terms of the high-level
         // mapping rather than any auxiliary encoding variables. Must be called

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,14 +62,26 @@ if(VERIPB_EXECUTABLE)
         --count-solutions --solution-limit 5 ${GSS_INSTANCES}/trident.csv ${GSS_INSTANCES}/longtrident.csv)
 
     # loop->loop mappings verify under plain VeriPB now the self-loop term is kept in
-    # the adjacency constraint (issue #49). (Supplemental graphs with loops are issue
-    # #56, hence --no-supplementals here.)
+    # the adjacency constraint (issue #49).
     gss_add_proof_test(proof_sat_loopy_decision ${SUB_MIN}
         --format lad ${GSS_INSTANCES}/small ${GSS_INSTANCES}/large)
     gss_add_proof_test(proof_count_loopy ${SUB_MIN}
         --count-solutions --format lad ${GSS_INSTANCES}/small ${GSS_INSTANCES}/large)
 
-    # --- Preprocessing / supplemental-graph proofs (loopless; loops are issue #56) ---
+    # Loops together with supplemental graphs (issue #56): the loop-bearing adjacency
+    # constraints are reduced to their loop-cancelled form before being summed into the
+    # supplemental-graph / degree / distance-3 pols (Proof::loop_fix_adjacencies), and
+    # the induced self-loop constraint completes the model. These exercise that path.
+    gss_add_proof_test(proof_supplementals_loopy ${SUB} --no-nds
+        --format lad ${GSS_INSTANCES}/small ${GSS_INSTANCES}/large)
+    gss_add_proof_test(proof_supplementals_loopy_induced ${SUB} --no-nds
+        --induced --format lad ${GSS_INSTANCES}/small ${GSS_INSTANCES}/large)
+    gss_add_proof_test(proof_count_loopy_supplementals ${SUB} --no-nds
+        --count-solutions --format lad ${GSS_INSTANCES}/small ${GSS_INSTANCES}/large)
+    gss_add_proof_test(proof_distance3_loopy ${SUB} --no-nds --distance3
+        --format lad ${GSS_INSTANCES}/small ${GSS_INSTANCES}/large)
+
+    # --- Preprocessing / supplemental-graph proofs (loopless) ---
     # supplemental (exact-path) graphs: create_exact_path_graphs derivations.
     gss_add_proof_test(proof_supplementals ${SUB} --no-nds
         ${GSS_INSTANCES}/trident.csv ${GSS_INSTANCES}/longtrident.csv)
@@ -131,8 +143,11 @@ if(VERIPB_EXECUTABLE)
         # complete enumeration of zero solutions (no triangle in a path)
         gss_add_cake_test(cake_unsat triangle.lad path4.lad --count-solutions)
         # loop->loop mapping, checked end to end by the verified pipeline
-        # (--no-supplementals: supplemental graphs with loops are issue #56)
         gss_add_cake_test(cake_loop_decision loop_vertex.lad loop_target.lad --no-supplementals)
         gss_add_cake_test(cake_loop_count loop_vertex.lad loop_target.lad --no-supplementals --count-solutions)
+        # loops together with supplemental graphs (issue #56): the loop-cancelled
+        # adjacency derivations are checked against cake's own OPB encoding too.
+        gss_add_cake_test(cake_loop_supplementals small large --no-nds)
+        gss_add_cake_test(cake_loop_supplementals_count small large --no-nds --count-solutions)
     endif()
 endif()

--- a/test-instances/random_proof_sweep.bash
+++ b/test-instances/random_proof_sweep.bash
@@ -1,9 +1,10 @@
 #!/bin/bash
 # Generate random instances and check that the solver's proof verifies on each,
 # across a spread of graph structures and option combinations. This catches
-# proof-logging bugs that the fixed instances miss -- a derivation that only breaks
-# on certain structures (e.g. issue #56 would have shown up here). Correctness of
-# the *counts* is checked separately and in-process by random_homomorphism_test.
+# proof-logging bugs that the fixed instances miss -- both loopless and loopy
+# instances are swept, since loops + supplemental graphs (issue #56) only break on
+# certain structures. Correctness of the *counts* is checked separately and
+# in-process by random_homomorphism_test.
 #
 # Deterministic: create_random_graph is seeded and the solver is run without
 # restarts, so every proof is reproducible.
@@ -28,32 +29,38 @@ workdir="$4"
 fails=0
 checked=0
 
-# loopless random graphs (no --loops): supplemental graphs are on by default, so the
-# exact-path / distance derivations get exercised; loops + supplementals is issue #56.
-for seed in $(seq 1 8); do
-    pat="${workdir}/rps_pattern_${seed}.csv"
-    tgt="${workdir}/rps_target_${seed}.csv"
-    "${crg}" --seed "${seed}" 5 0.5 > "${pat}"
-    "${crg}" --seed "$((seed + 100))" 8 0.45 > "${tgt}"
-
-    for opts in "" "--induced" "--count-solutions" "--induced --count-solutions"; do
-        checked=$((checked + 1))
-        proof="${workdir}/rps_proof_${seed}_${checked}"
-
+# Two families: loopless (no --loops) and loopy (--loops). Supplemental graphs are on
+# by default in both, so the exact-path / distance-3 / degree / NDS derivations are
+# exercised, and the loopy family additionally drives the loop-cancellation path
+# (issue #56). Each uses the same option spread.
+for loops in "" "--loops 0.3"; do
+    for seed in $(seq 1 8); do
+        pat="${workdir}/rps_pattern_${seed}.csv"
+        tgt="${workdir}/rps_target_${seed}.csv"
         # shellcheck disable=SC2086
-        if ! "${solver}" --format csv --no-clique-detection ${opts} --prove "${proof}" \
-                "${pat}" "${tgt}" > "${proof}.log" 2>&1; then
-            echo "seed ${seed}, opts '${opts}': solver failed" 1>&2
-            cat "${proof}.log" 1>&2
-            fails=$((fails + 1))
-            continue
-        fi
+        "${crg}" --seed "${seed}" ${loops} 5 0.5 > "${pat}"
+        # shellcheck disable=SC2086
+        "${crg}" --seed "$((seed + 100))" ${loops} 8 0.45 > "${tgt}"
 
-        if ! "${veripb}" "${proof}.opb" "${proof}.pbp" 2>&1 | grep -q 'VERIFIED'; then
-            echo "seed ${seed}, opts '${opts}': proof did NOT verify" 1>&2
-            "${veripb}" "${proof}.opb" "${proof}.pbp" 2>&1 | tail -4 1>&2
-            fails=$((fails + 1))
-        fi
+        for opts in "" "--induced" "--count-solutions" "--induced --count-solutions" "--distance3"; do
+            checked=$((checked + 1))
+            proof="${workdir}/rps_proof_${seed}_${checked}"
+
+            # shellcheck disable=SC2086
+            if ! "${solver}" --format csv --no-clique-detection ${opts} --prove "${proof}" \
+                    "${pat}" "${tgt}" > "${proof}.log" 2>&1; then
+                echo "loops='${loops}' seed ${seed}, opts '${opts}': solver failed" 1>&2
+                cat "${proof}.log" 1>&2
+                fails=$((fails + 1))
+                continue
+            fi
+
+            if ! "${veripb}" "${proof}.opb" "${proof}.pbp" 2>&1 | grep -q 'VERIFIED'; then
+                echo "loops='${loops}' seed ${seed}, opts '${opts}': proof did NOT verify" 1>&2
+                "${veripb}" "${proof}.opb" "${proof}.pbp" 2>&1 | tail -4 1>&2
+                fails=$((fails + 1))
+            fi
+        done
     done
 done
 


### PR DESCRIPTION
Fixes #56. Proof logging now works on loopy instances together with supplemental
graphs, distance-3 filtering, degree and neighbourhood-degree-sequence reasoning,
under both plain VeriPB and the verified CakePB pipeline.

## The two bugs

1. **Loop term as a pol stray.** Issue #49 keeps the target self-loop term in the
   adjacency constraint (so a loop→loop mapping satisfies the model), but that term
   is a stray once `@adj` is summed into a pseudo-Boolean derivation. So the degree,
   NDS, supplemental-graph and distance-3 pols failed to verify on loopy instances.

2. **Induced encoding unsound for loops.** The induced non-edge loop skipped `q == p`
   and the edge loop only constrained a loopy `p`, so a non-loopy pattern vertex
   mapping to a loopy target was never forbidden — the OPB admitted mappings that
   aren't valid induced solutions (e.g. `{0→0, 1→1}` for a non-loopy pattern into a
   loopy target), so no proof could justify the (correct) pruning.

## The fix

- **`Proof::loop_fix_adjacencies`** reassigns each loop-bearing `@adj` label (for
  `p != q`) to its loop-cancelled form `~x_p_t + Σ_{u∈N(t)\{t}} x_q_u`, which follows
  from the constraint plus injectivity on `t` (mapping `p` to `t` forbids `q` from
  also mapping to `t`). VeriPB allows relabelling, so every pol picks up the
  loop-cancelled form by label with no call-site changes; the original loop-bearing
  constraint stays in the database so solutions still satisfy the model. This is the
  pre-#49 encoding reconstructed on demand, only where it's summed into a derivation.
- **Induced self-loop constraint**: add the `q == p` case of induced non-edge
  preservation, closing the soundness gap.
- **Up-front loop-incompatibility units** so search propagations can use them.
- The guard refusing loops + supplementals is removed.

## Tests / docs

- New ctests: `proof_supplementals_loopy[_induced]`, `proof_count_loopy_supplementals`,
  `proof_distance3_loopy`, and `cake_loop_supplementals[_count]` (end-to-end verified).
- The random proof sweep now sweeps loopy instances too (this class of bug only shows
  on certain structures, so a fixed instance wouldn't catch a regression).
- `dev_docs/proof-logging.md` updated; the #56 limitation row is gone.

All proof-only changes — solving behaviour is unchanged (the random correctness oracle
is still green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)