### PR TITLE
Fix locally-injective enumeration over-pruning (#58)

### DIFF
--- a/gss/innards/homomorphism_model.cc
+++ b/gss/innards/homomorphism_model.cc
@@ -40,13 +40,13 @@ using std::chrono::steady_clock;
 
 namespace
 {
-    auto calculate_n_shape_graphs(const HomomorphismParams & params) -> unsigned
+    auto calculate_n_shape_graphs(const HomomorphismParams & params, bool has_loops) -> unsigned
     {
         return 1 +
-            (supports_exact_path_graphs(params) ? params.number_of_exact_path_graphs : 0) +
-            (supports_distance2_graphs(params) ? 1 : 0) +
+            (supports_exact_path_graphs(params, has_loops) ? params.number_of_exact_path_graphs : 0) +
+            (supports_distance2_graphs(params, has_loops) ? 1 : 0) +
             (supports_distance3_graphs(params) ? 1 : 0) +
-            (supports_k4_graphs(params) ? 1 : 0) +
+            (supports_k4_graphs(params, has_loops) ? 1 : 0) +
             params.extra_shapes.size();
     }
 
@@ -126,6 +126,7 @@ struct HomomorphismModel::Imp
 
     vector<int> pattern_vertex_labels, target_vertex_labels, pattern_edge_labels, target_edge_labels;
     vector<int> pattern_loops, target_loops;
+    bool has_loops = false;
 
     vector<string> pattern_vertex_proof_names, target_vertex_proof_names;
 
@@ -149,10 +150,12 @@ struct HomomorphismModel::Imp
 HomomorphismModel::HomomorphismModel(const InputGraph & target, const InputGraph & pattern, const HomomorphismParams & params,
     const std::shared_ptr<Proof> & proof) :
     _imp(make_unique<Imp>(params, proof)),
-    max_graphs(calculate_n_shape_graphs(params)),
+    max_graphs(calculate_n_shape_graphs(params, pattern.loopy() || target.loopy())),
     pattern_size(pattern.size()),
     target_size(target.size())
 {
+    _imp->has_loops = pattern.loopy() || target.loopy();
+
     if (_imp->params.clique_size_constraints)
         _imp->max_graphs_for_clique_size_constraints = (_imp->params.clique_size_constraints_on_supplementals ? max_graphs : 1);
 
@@ -496,7 +499,7 @@ auto HomomorphismModel::_check_degree_compatibility(
     vector<vector<optional<vector<int>>>> & targets_ndss,
     bool do_not_do_nds_yet) const -> bool
 {
-    if (! degree_and_nds_are_preserved(_imp->params))
+    if (! degree_and_nds_are_preserved(_imp->params, _imp->has_loops))
         return true;
 
     for (unsigned g = 0; g < graphs_to_consider; ++g) {
@@ -595,7 +598,7 @@ auto HomomorphismModel::initialise_domains(vector<HomomorphismDomain> & domains)
     vector<vector<vector<int>>> patterns_ndss(max_graphs_for_degree_things);
     vector<vector<optional<vector<int>>>> targets_ndss(max_graphs_for_degree_things);
 
-    if (degree_and_nds_are_preserved(_imp->params) && ! _imp->params.no_nds) {
+    if (degree_and_nds_are_preserved(_imp->params, _imp->has_loops) && ! _imp->params.no_nds) {
         for (unsigned g = 0; g < max_graphs_for_degree_things; ++g) {
             patterns_ndss.at(g).resize(pattern_size);
             targets_ndss.at(g).resize(target_size);
@@ -642,7 +645,7 @@ auto HomomorphismModel::initialise_domains(vector<HomomorphismDomain> & domains)
     }
 
     // for proof logging, we need degree information before we can output nds proofs
-    if (_imp->proof && degree_and_nds_are_preserved(_imp->params) && ! _imp->params.no_nds) {
+    if (_imp->proof && degree_and_nds_are_preserved(_imp->params, _imp->has_loops) && ! _imp->params.no_nds) {
         for (unsigned i = 0; i < pattern_size; ++i) {
             for (unsigned j = 0; j < target_size; ++j) {
                 if (domains.at(i).values.test(j) &&
@@ -785,7 +788,7 @@ auto HomomorphismModel::prepare() -> bool
 
     unsigned next_pattern_supplemental = 1, next_target_supplemental = 1;
     // build exact path graphs
-    if (supports_exact_path_graphs(_imp->params)) {
+    if (supports_exact_path_graphs(_imp->params, _imp->has_loops)) {
         _build_exact_path_graphs(_imp->pattern_graph_rows, pattern_size, next_pattern_supplemental, _imp->params.number_of_exact_path_graphs, _imp->directed, false, true);
         _build_exact_path_graphs(_imp->target_graph_rows, target_size, next_target_supplemental, _imp->params.number_of_exact_path_graphs, _imp->directed, false, false);
 
@@ -848,7 +851,7 @@ auto HomomorphismModel::prepare() -> bool
         }
     }
 
-    if (supports_distance2_graphs(_imp->params)) {
+    if (supports_distance2_graphs(_imp->params, _imp->has_loops)) {
         _build_exact_path_graphs(_imp->pattern_graph_rows, pattern_size, next_pattern_supplemental, 1, _imp->directed, true, true);
         _build_exact_path_graphs(_imp->target_graph_rows, target_size, next_target_supplemental, 1, _imp->directed, true, false);
     }
@@ -952,7 +955,7 @@ auto HomomorphismModel::prepare() -> bool
         }
     }
 
-    if (supports_k4_graphs(_imp->params)) {
+    if (supports_k4_graphs(_imp->params, _imp->has_loops)) {
         _build_k4_graphs(_imp->pattern_graph_rows, pattern_size, next_pattern_supplemental, true);
         _build_k4_graphs(_imp->target_graph_rows, target_size, next_target_supplemental, false);
     }

--- a/gss/innards/homomorphism_traits.cc
+++ b/gss/innards/homomorphism_traits.cc
@@ -3,20 +3,29 @@
 using namespace gss;
 using namespace gss::innards;
 
-auto gss::innards::supports_exact_path_graphs(const HomomorphismParams & params) -> bool
+// Local injectivity together with a self-loop makes the loop-stripped, injective-style
+// supplemental and degree/NDS reasoning unsound (issue #58): a neighbour can map onto a
+// target self-loop, which the stripped rows and the "distinct images" counting miss. In
+// that one case fall back to adjacency + local-injectivity propagation, which is correct.
+static auto loop_breaks_filtering(const gss::HomomorphismParams & params, bool has_loops) -> bool
 {
-    return (! params.no_supplementals) && (params.injectivity != Injectivity::NonInjective);
+    return params.injectivity == gss::Injectivity::LocallyInjective && has_loops;
 }
 
-auto gss::innards::supports_distance2_graphs(const HomomorphismParams & params) -> bool
+auto gss::innards::supports_exact_path_graphs(const HomomorphismParams & params, bool has_loops) -> bool
+{
+    return (! params.no_supplementals) && (params.injectivity != Injectivity::NonInjective) && (! loop_breaks_filtering(params, has_loops));
+}
+
+auto gss::innards::supports_distance2_graphs(const HomomorphismParams & params, bool has_loops) -> bool
 {
     // exact path graphs are better
-    return (! params.no_supplementals) && (! supports_exact_path_graphs(params));
+    return (! params.no_supplementals) && (! supports_exact_path_graphs(params, has_loops)) && (! loop_breaks_filtering(params, has_loops));
 }
 
-auto gss::innards::supports_k4_graphs(const HomomorphismParams & params) -> bool
+auto gss::innards::supports_k4_graphs(const HomomorphismParams & params, bool has_loops) -> bool
 {
-    return (! params.no_supplementals) && params.k4 && (params.injectivity != Injectivity::NonInjective);
+    return (! params.no_supplementals) && params.k4 && (params.injectivity != Injectivity::NonInjective) && (! loop_breaks_filtering(params, has_loops));
 }
 
 auto gss::innards::supports_distance3_graphs(const HomomorphismParams & params) -> bool
@@ -34,14 +43,20 @@ auto gss::innards::is_nonshrinking(const HomomorphismParams & params) -> bool
     return params.injectivity == Injectivity::Injective;
 }
 
-auto gss::innards::degree_and_nds_are_preserved(const HomomorphismParams & params) -> bool
+auto gss::innards::degree_and_nds_are_preserved(const HomomorphismParams & params, bool has_loops) -> bool
 {
-    return params.injectivity != Injectivity::NonInjective;
+    return (params.injectivity != Injectivity::NonInjective) && (! loop_breaks_filtering(params, has_loops));
 }
 
 auto gss::innards::degree_and_nds_are_exact(const HomomorphismParams & params, unsigned pattern_size, unsigned target_size) -> bool
 {
-    return params.induced && pattern_size == target_size;
+    // Degrees (and neighbourhood degree sequences) must match *exactly* only when the
+    // mapping is forced to be a bijection -- i.e. an induced graph isomorphism. That needs
+    // full injectivity: an injection between equal-sized vertex sets is onto. Under merely
+    // local injectivity the mapping can collide, so a degree-d pattern vertex may map to a
+    // higher-degree target (only deg(image) >= d is required), and demanding equality
+    // wrongly prunes those (issue #58).
+    return params.induced && pattern_size == target_size && params.injectivity == Injectivity::Injective;
 }
 
 auto gss::innards::global_degree_is_preserved(const HomomorphismParams & params) -> bool

--- a/gss/innards/homomorphism_traits.hh
+++ b/gss/innards/homomorphism_traits.hh
@@ -5,11 +5,16 @@
 
 namespace gss::innards
 {
-    auto supports_exact_path_graphs(const HomomorphismParams & params) -> bool;
+    // has_loops is whether the pattern or target has any self-loop. The supplemental-graph
+    // and degree/NDS filters reason with loop-stripped rows and an injective counting
+    // argument; under *local* injectivity with a loop present that argument is unsound (a
+    // neighbour may map onto a target self-loop), so these are disabled for that case and
+    // the search falls back to adjacency + local-injectivity propagation (issue #58).
+    auto supports_exact_path_graphs(const HomomorphismParams & params, bool has_loops) -> bool;
 
-    auto supports_distance2_graphs(const HomomorphismParams & params) -> bool;
+    auto supports_distance2_graphs(const HomomorphismParams & params, bool has_loops) -> bool;
 
-    auto supports_k4_graphs(const HomomorphismParams & params) -> bool;
+    auto supports_k4_graphs(const HomomorphismParams & params, bool has_loops) -> bool;
 
     auto supports_distance3_graphs(const HomomorphismParams & params) -> bool;
 
@@ -17,7 +22,7 @@ namespace gss::innards
 
     auto is_nonshrinking(const HomomorphismParams & params) -> bool;
 
-    auto degree_and_nds_are_preserved(const HomomorphismParams & params) -> bool;
+    auto degree_and_nds_are_preserved(const HomomorphismParams & params, bool has_loops) -> bool;
 
     auto degree_and_nds_are_exact(const HomomorphismParams & params, unsigned pattern_size, unsigned target_size) -> bool;
 

--- a/gss/random_homomorphism_test.cc
+++ b/gss/random_homomorphism_test.cc
@@ -99,12 +99,12 @@ TEST_CASE("random instances: solver enumeration matches the brute-force oracle")
         auto target = random_graph(nt, target_density, loop_probability, rng);
 
         bool induced = (rng() % 2);
-        // Injective and non-injective only: locally-injective enumeration is currently
-        // wrong (over-prunes), tracked as issue #58 -- re-enable that arm once it's fixed.
-        int injectivity_choice = rng() % 2;
-        auto injectivity = injectivity_choice == 0 ? Injectivity::Injective : Injectivity::NonInjective;
+        int injectivity_choice = rng() % 3;
+        auto injectivity = injectivity_choice == 0 ? Injectivity::Injective
+            : injectivity_choice == 1 ? Injectivity::NonInjective
+                                      : Injectivity::LocallyInjective;
         bool injective = (injectivity == Injectivity::Injective);
-        bool locally_injective = false;
+        bool locally_injective = (injectivity == Injectivity::LocallyInjective);
 
         auto expected = brute_force_solutions(pattern, target, injective, locally_injective, induced);
 


### PR DESCRIPTION
Fixes #58. `--locally-injective` produced too-small solution counts. Two distinct
causes, both in filtering that implicitly assumed injective semantics. The oracle
(`verify_homomorphism`) was checked first and is correct; there is no OPB encoding
for local injectivity (proof logging guards it off), so this is purely solver-side.

## Bug 1 — `degree_and_nds_are_exact` (loopless)
It returned `induced && pattern_size == target_size`. Exact degrees only hold when
the mapping must be a **bijection** (an induced graph isomorphism), which requires
full injectivity — an injection between equal-sized vertex sets is onto. Under local
injectivity the mapping can collide, so a degree-`d` pattern vertex may map to a
higher-degree target (only `deg(image) >= d` is required); demanding equality wrongly
pruned those. Minimal repro from the issue (3 isolated pattern vertices → one-edge
target) now gives 15, matching non-injective, instead of 1.

## Bug 2 — loops
The degree, NDS and supplemental-graph filters use loop-stripped rows and an injective
counting argument. With a self-loop that's unsound for local injectivity: a pattern
vertex's neighbour can map onto a target self-loop, but the loopy target's stripped
degree reads as 0, so a degree-1 pattern vertex was refused it. Adjacency + local-
injectivity propagation alone are correct here (verified), so those filters are disabled
for the locally-injective-**with-loops** case, threaded through a `has_loops` flag.
Loopless local injectivity keeps the filters (sound there).

## Testing
`random_homomorphism_test` re-enables the locally-injective arm that #58 had disabled;
it now agrees with `verify_homomorphism` across injective / non-injective / locally-
injective. Verified on the committed seed (1500 iterations) and independently on a
different seed (6000 iterations / 18000 assertions). Full `ctest` (42 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)