### PR TITLE
CI: key the Release ccache on the CPU's ISA

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,10 +20,29 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    # Release builds bake the build CPU's ISA into the objects (-march=native, see
+    # CMakeLists.txt). The runner CPU varies between jobs, so a cached object compiled on
+    # a runner with a richer ISA must not be reused on one that lacks those instructions:
+    # it would execute an illegal instruction (SIGILL). Fold the CPU's feature set into
+    # the ccache key so only ISA-compatible runners share objects. (The sanitize and
+    # coverage jobs don't use -march=native, so their caches stay CPU-agnostic.)
+    - name: Compute CPU signature for ccache key
+      id: cpu
+      shell: bash
+      run: |
+        if [ -r /proc/cpuinfo ]; then
+          sig=$(grep -m1 -E '^(flags|Features)[[:space:]]*:' /proc/cpuinfo)
+        else
+          sig="$(sysctl -n machdep.cpu.brand_string 2>/dev/null) $(uname -m)"
+        fi
+        h=$(printf '%s' "$sig" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-16)
+        echo "hash=$h" >> "$GITHUB_OUTPUT"
+        echo "CPU signature -> $h"
+
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: ${{ matrix.os }}-release
+        key: ${{ matrix.os }}-release-${{ steps.cpu.outputs.hash }}
 
     - name: Install dependencies (Linux)
       if: startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
## Problem

Release builds use `-march=native` (`CMakeLists.txt`, Release-only), which bakes the build runner's instruction set into the compiled objects. The matrix (Release) job's ccache was keyed only on the OS (`${{ matrix.os }}-release`). GitHub Actions runners of the same OS label vary in physical CPU microarchitecture, so an object compiled with `-march=native` on a runner with a richer ISA (e.g. AVX-512) could be restored from cache onto a later run whose runner CPU lacks those instructions — the resulting binary then executes an illegal instruction and dies with **`SIGILL`**.

This presents as a non-reproducible, layout-sensitive crash on a random Release lane (it cannot be reproduced locally, since you build and run on the same CPU). The most recent occurrence was the `random_homomorphism_test` solve on `ubuntu-24.04`, where the run reported **100% ccache hits (146/146), 0 misses** — i.e. the whole binary was assembled from objects compiled on an earlier, different runner. The sanitize and coverage lanes never reproduce it because they don't build Release / don't use `-march=native`.

## Fix

Fold a hash of the CPU's feature set (the `flags`/`Features` line of `/proc/cpuinfo`, or the brand string on macOS) into the Release ccache key, so only ISA-compatible runners share cached objects. The sanitize and coverage jobs don't use `-march=native`, so their caches remain CPU-agnostic and are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)