### PR TITLE
Proof-size measurement harness (solve-pipeline refactor, Phase 0)

### DIFF
--- a/dev_docs/preprocessor-refactor.md
+++ b/dev_docs/preprocessor-refactor.md
@@ -1,0 +1,183 @@
+# Refactoring the solve pipeline
+
+A design plan for restructuring everything the homomorphism solver does "before search"
+into a uniform, reorderable pipeline. This is forward-looking — it describes where the
+code is going, not where it is. For the current architecture see
+[architecture.md](architecture.md); for proof logging see
+[proof-logging.md](proof-logging.md). Scope is the **homomorphism** solver only; the
+clique and common-subgraph solvers are deliberately left alone.
+
+## Why
+
+Four things are awkward today, and they share a root cause — preprocessing is a fixed,
+implicit sequence split across four sites with proof emission inlined into it:
+
+- **S1 — adding a feature is a 5–7 site change.** A new supplemental graph or filter
+  touches `calculate_n_shape_graphs`, a `_build_*` method, a `supports_*` trait, an
+  `if`-block in `prepare()` with manual `next_pattern_supplemental` / `next_target_supplemental`
+  index threading, a parallel inline proof loop, the slot-index sanity check, and the
+  `_check_*` chain plus its NDS-style proof second pass. There is no single registration
+  point.
+- **S2 — proofs are bigger than they need to be.**
+  - S2a: supplemental-graph derivations are emitted to the proof for *every* `(g, p, q, t)`
+    triple regardless of whether anything ever filters on that edge, plus the eager
+    loop-incompatibility block and `loop_fix_adjacencies` over every loopy adjacency.
+  - S2b: the full OPB model is emitted before any refutation check runs — even
+    `pattern > target` writes the entire model first.
+- **S3 — no reordering or staging.** `prepare()` builds every applicable supplemental
+  unconditionally; there is no way to reorder steps, nor to "run fast preprocessing,
+  search for a bit, and only then run full preprocessing".
+- **S4 — the sequence is hard to follow.** Control flow is spread across the
+  `HomomorphismModel` constructor, `solve_homomorphism_problem`, `prepare()`, and
+  `initialise_domains()`, with proof scaffolding inlined into the build loops
+  (`prepare()` is ~320 lines, about half of it proof emission).
+
+A telling observation: the current code *already* concludes the problem during
+"preprocessing" — `global_degree_is_preserved` Hall checking returns UNSAT, and the
+loop shortcut and clique reduction return SAT — they are just special-cased as early
+returns in `solve_homomorphism_problem`. The preprocess/search distinction is artificial.
+
+## Two economies that are NOT available
+
+Before the design, two tempting ideas that do not work, so we do not attempt them:
+
+- **Minimal / lazy OPB — no.** The OPB is the trusted encoding. A checker has no
+  independent way to confirm that a partial OPB is still a faithful, complete model of
+  the instance, so omitting any model constraint is indistinguishable from cheating
+  (silently making the instance over-permissive). The OPB always contains the complete
+  encoding — adjacency, (local-)injectivity, domains — no more and no less. (Counterpart
+  rule: do not *add* derived consequences to the OPB either; derive them in the proof.)
+- **Lazy-on-cite proof emission — no.** RUP steps record nothing about which constraints
+  they consume; VeriPB unit-propagates over the whole database. Once a derived constraint
+  exists, any later RUP — every search nogood included — can silently rely on it. We can
+  never prove a derived constraint is unused, so we cannot defer or omit it on demand.
+
+So **S2a is achieved by static subsumption / inertness elimination**: do not *generate*
+the useless supplementals in the first place. This is decidable, result-preserving, and
+a search-speed win (fewer model bitset rows), not only a smaller proof:
+
+- A whole supplemental-graph pair `(Pˢ, Gˢ)` is inert — skip it entirely, no slot, no
+  build, no derivations — when, by direct bitset checks: `Gˢ` is complete (the adjacency
+  constraint is vacuous and degree/NDS on it are maximal so cannot fire), or `Pˢ` is
+  empty (no constraints generated), or `(Pˢ, Gˢ)` duplicates an already-registered slot.
+  Dense instances are where this bites: distance-3 / exact-path graphs often saturate to
+  complete (maximal proof, zero filtering), and duplicates between e.g. distance-2 and
+  exact-path-1 are common.
+- Within a graph we do keep, do not derive a constraint subsumed by one already derived
+  (cite the stronger one where a `pol` step would otherwise reference the weaker).
+
+No justification step is needed: the OPB is untouched (supplementals were never in it),
+we simply decline to derive and to allocate inert ones.
+
+## The abstraction: a unified `SolveStep`
+
+One step type, no preprocess/search distinction. A step is **a partial solver: a
+transformer of shared state that may also conclude the problem.** It may (a) tighten
+domains, (b) produce data later steps consume (a supplemental graph, degrees, NDS,
+clique sizes, nogoods), (c) conclude (SAT / UNSAT / enumeration-complete), or (d) make
+progress and hand off.
+
+```cpp
+struct SolveStep {
+    virtual auto name() const -> std::string;
+    virtual auto cost() const -> Cost;                                  // Fast / Medium / Expensive
+    virtual auto applicable(const HomomorphismParams &, const SolveState &) const -> bool;
+    virtual auto run(SolveState &) -> StepOutcome;   // Continue | Concluded(result) | Aborted
+};
+```
+
+- **`SolveState`** is the shared working state, spanning what is today split between
+  `HomomorphismModel` and the searcher: domains; the model graph rows plus slot
+  allocation (`max_graphs` *grows* as builders commit) plus degree / NDS / clique caches;
+  accumulated nogoods / watches; the best mapping and solution count; the `Proof` object;
+  and the timeout / budget.
+- **`applicable()`** subsumes the `supports_*` traits *and* the mode gates — e.g. the
+  loop shortcut is "not applicable when counting" (today's `! params.count_solutions`) —
+  so a step's possible findings are always mode-appropriate by construction.
+- **`StepOutcome`** is `Continue` (drove state forward, not done), `Concluded(result)`
+  (the driver emits the matching proof conclusion and stops), or `Aborted` (budget /
+  timeout → unknown). This outcome shape is provisional; revisit if it proves awkward.
+
+Steps are then: setup (recode, emit OPB model), filters (degree / label / loop /
+global-degree / NDS / clique / Hall), graph builders (exact-path / distance-2 / distance-3
+/ k4 / extra-shape, each of which *commits or discards* a candidate slot), shortcuts
+(pattern > target, loop, clique reduction), and **search** — a bounded or unbounded
+search engine wrapped as a step. The registered step list *is* the documented,
+reorderable solve strategy.
+
+**Staging (S3) is then native, not bolted on.** "Run fast preprocessing, search a bit,
+then full preprocessing" is just a step list: Fast filters → cheap builders → a *bounded*
+search step (which returns `Continue` after recording nogoods if it does not conclude) →
+Expensive builders (which re-filter against the new graphs and accumulated nogoods) → an
+unbounded search step. Nogoods persist in `SolveState` across rounds and feed the later
+search.
+
+## Staged execution
+
+Each phase is an independently mergeable PR.
+
+- **Phase 0 — Instrument, no behaviour change.** Add PBP line-count, OPB size,
+  `max_graphs`, and solution-count columns to `test-instances/random_proof_sweep.bash`
+  plus a ctest, so every later win is measurable and Phases 1–3 can be proven
+  byte-identical.
+- **Phase 1 — Extract the solve pipeline (S4; S1 foundation).** Introduce `SolveStep` and
+  a pipeline driver; move the existing phases into steps **in the same order, with no
+  logic change** — the cheap checks and shortcuts become steps, and the existing
+  sequential search becomes the **terminal step**. Keep the `HomomorphismModel` / searcher
+  boundary and have the search step wrap the existing engine; do **not** unify `SolveState`
+  yet. Guardrail: byte-identical proofs (sweep + cake).
+- **Phase 1b — Unify `SolveState`.** Fold model rows + domains + watches into one carried
+  state, the model "frozen" during a search step and mutable between steps. Deferred until
+  Phase 6 needs growable-model-across-rounds; isolated so it can land on its own.
+  Guardrail: byte-identical proofs.
+- **Phase 2 — Self-allocating slots + commit/discard (S1).** Replace
+  `calculate_n_shape_graphs`, the manual `next_*_supplemental` threading, and the
+  slot-index sanity check with context-driven slot allocation; `max_graphs` becomes a
+  result of registration. The discard path exists but always commits (no behaviour change
+  yet). Proofs unchanged.
+- **Phase 3 — Co-locate proof emission (S1, S4).** Move each inline proof loop out of
+  `prepare()` into its step, behind a narrow proof interface. Byte-identical. After this,
+  a new graph or filter is genuinely one new file.
+- **Phase 4 — Inert / duplicate supplemental elimination (S2a).** Turn on the discard
+  path: skip empty-`Pˢ` / complete-`Gˢ` / duplicate `(Pˢ, Gˢ)`; optionally follow with
+  constraint-level subsumption. Guardrail: identical solution counts (correctness sweep);
+  smaller proofs that still verify (proof sweep); Phase 0 metrics quantify the win.
+- **Phase 5 — Cost ordering + reorderable strategy (S2b; S3 ordering).** Steps declare a
+  cost; cheap concluding steps run before expensive builders, so easy-unsat instances
+  conclude before any supplemental derivations are emitted. The order is a property of the
+  registered list. Guardrail: proofs still verify; measurable PBP shrink on easy instances.
+- **Phase 6 — Staged solving (S3, first-class).** Bounded-search steps interleaved with
+  builder / filter steps; nogoods persist across rounds; re-filter after new graphs.
+  Requires Phase 1b. Sequential staging first; threaded staging is a later refinement (the
+  threaded engine has internal barriers and nogood sharing, so a *bounded threaded* step is
+  harder — the unbounded threaded search stays terminal meanwhile). Ship behind a flag,
+  measure, then consider making it the default.
+
+### Strand → phase
+
+| Strand | Delivered by |
+| --- | --- |
+| S1 (extensibility) | Phases 1–3 |
+| S2a (don't emit unused) | Phase 4 (needs Phase 2's discard) |
+| S2b (shortcut obvious unsat) | Phase 5 |
+| S3 (reorder + stage) | Phase 5 (reorder) + Phase 6 (stage) |
+| S4 (sequencing clarity) | Phases 1, 3 |
+
+## Risks and invariants
+
+- The `<directed, has_edge_labels, induced, verbose_proofs>` templated propagation hot
+  loop stays out of scope — only the engine *wrapping* it becomes a step.
+- Proof byte-stability is the contract for Phases 1–3; Phases 4 onward change proofs
+  deliberately, verified by re-running the sweeps, not by diff.
+- The OPB stays complete. `finalise_model` is unavoidably up front — even a cheap
+  refutation's proof cites OPB constraints — so the S2b / S3 deferral is of *derivations*,
+  not of the model.
+- Model-growth vs threading: under staging the model can only grow at a barrier between
+  threaded-search rounds (it is shared `const` across threads), hence sequential staging
+  first.
+- Proof under staging: deriving supplementals mid-proof (after a search round) is legal
+  but interacts with the existing "no counting with restarts under proof" restriction;
+  staged + counting + proof will likely need the same guard initially.
+- Preserve the locally-injective / loops gating (issues #56, #58) exactly when the
+  `supports_*` traits become `applicable()`. `extra_shapes` re-enters
+  `solve_homomorphism_problem` and is simply another step.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,19 @@ target_link_libraries(create_random_graph PRIVATE cxxopts)
 add_executable(convert_to_lad convert_to_lad.cc)
 target_link_libraries(convert_to_lad PRIVATE cxxopts)
 
+# Proof-size metrics over a fixed, representative matrix (see
+# dev_docs/preprocessor-refactor.md). Pure measurement: it emits a TSV of the
+# supplemental-graph count and OPB/PBP line counts per configuration, the baseline that
+# the solve-pipeline refactor's later phases diff against. It needs no VeriPB, so it is
+# registered unconditionally and runs in every lane, doubling as a proof-emission smoke
+# test (under the sanitizers it exercises proof.cc across many feature combinations).
+add_test(NAME proof_metrics
+    COMMAND ${CMAKE_SOURCE_DIR}/test-instances/proof_metrics.bash
+        $<TARGET_FILE:glasgow_subgraph_solver>
+        ${CMAKE_SOURCE_DIR}/test-instances
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}/proof_metrics.tsv)
+
 # Proof-verification tests: run the solver with proof logging on a small instance
 # and check the resulting proof with VeriPB. Only registered when VeriPB was found
 # at configure time (find_program in the top-level CMakeLists), so a checkout

--- a/test-instances/proof_metrics.bash
+++ b/test-instances/proof_metrics.bash
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Measure proof-emission size across a fixed, representative matrix of instances and
+# option combinations. This is the deterministic baseline that the solve-pipeline
+# refactor (see dev_docs/preprocessor-refactor.md) diffs against, phase by phase:
+# Phases 1-3 must leave these numbers unchanged (pure refactors), and Phase 4 onward
+# should shrink the supplemental-graph count and PBP line count without changing the
+# solution counts.
+#
+# For each configuration it records: the number of supplemental ("shape") graphs built,
+# the OPB (model) line count, the PBP (proof) line count, the solution count / status,
+# and the node count. It deliberately does NOT run VeriPB -- it is pure measurement, so
+# it is fast and runs in every lane, doubling as a proof-emission smoke test over many
+# feature combinations (under the sanitizers it exercises proof.cc with no VeriPB needed).
+#
+# The option combinations mirror ones the proof ctests already verify, so each is known
+# to emit a checkable proof; here we only measure what it emits.
+#
+# Usage:
+#   proof_metrics.bash <solver> <instances_dir> <workdir> [out.tsv]
+#
+# Prints a TSV table to stdout (and to out.tsv if given). Exits 0 iff every solver
+# invocation succeeded.
+
+set -u
+
+if [ "$#" -lt 3 ]; then
+    echo "usage: $0 <solver> <instances_dir> <workdir> [out.tsv]" 1>&2
+    exit 2
+fi
+
+solver="$1"
+inst="$2"
+workdir="$3"
+out="${4:-}"
+
+# Proof logging always needs --no-clique-detection. SUB_MIN additionally turns off the
+# supplemental graphs and NDS (the leanest proof); the other rows turn individual
+# techniques back on so their emission is measured in isolation.
+common="--no-clique-detection"
+min="${common} --no-supplementals --no-nds"
+
+# label | solver options | pattern | target
+configs=(
+    "decision|${min} --format csv|trident.csv|longtrident.csv"
+    "count|${min} --count-solutions --format csv|trident.csv|longtrident.csv"
+    "induced_unsat|${min} --induced --format csv|c3.csv|trident.csv"
+    "supplementals|${common} --no-nds --format csv|trident.csv|longtrident.csv"
+    "distance3|${common} --no-nds --distance3 --format csv|trident.csv|longtrident.csv"
+    "nds|${common} --no-supplementals --format csv|trident.csv|longtrident.csv"
+    "cliques|${common} --no-supplementals --no-nds --cliques --format csv|trident.csv|longtrident.csv"
+    "locally_injective|${min} --locally-injective --count-solutions --format csv|trident.csv|longtrident.csv"
+    "loopy_supplementals|${common} --no-nds --format lad|small|large"
+)
+
+header=$'config\tshape_graphs\topb_lines\tpbp_lines\tsolutions\tnodes'
+printf '%s\n' "${header}"
+[ -n "${out}" ] && printf '%s\n' "${header}" > "${out}"
+
+rc=0
+for row in "${configs[@]}"; do
+    IFS='|' read -r label opts pat tgt <<< "${row}"
+    proof="${workdir}/pm_${label}"
+    log="${proof}.log"
+
+    # shellcheck disable=SC2086
+    if ! "${solver}" ${opts} --prove "${proof}" "${inst}/${pat}" "${inst}/${tgt}" > "${log}" 2>&1; then
+        echo "${label}: solver failed" 1>&2
+        cat "${log}" 1>&2
+        rc=1
+        continue
+    fi
+
+    opb_lines=$(wc -l < "${proof}.opb")
+    pbp_lines=$(wc -l < "${proof}.pbp")
+    shape=$(sed -n 's/^shape_graphs = //p' "${log}"); shape="${shape:-NA}"
+    sols=$(sed -n 's/^solution_count = //p' "${log}")
+    [ -z "${sols}" ] && sols=$(sed -n 's/^status = //p' "${log}")
+    sols="${sols:-NA}"
+    nodes=$(sed -n 's/^nodes = //p' "${log}"); nodes="${nodes:-NA}"
+
+    line=$(printf '%s\t%s\t%s\t%s\t%s\t%s' "${label}" "${shape}" "${opb_lines}" "${pbp_lines}" "${sols}" "${nodes}")
+    printf '%s\n' "${line}"
+    [ -n "${out}" ] && printf '%s\n' "${line}" >> "${out}"
+done
+
+exit "${rc}"

--- a/test-instances/random_proof_sweep.bash
+++ b/test-instances/random_proof_sweep.bash
@@ -12,7 +12,10 @@
 # Usage:
 #   random_proof_sweep.bash <solver> <veripb> <create_random_graph> <workdir>
 #
-# Exits 0 iff every generated proof verifies.
+# Exits 0 iff every generated proof verifies. Also records per-instance proof-size
+# metrics (supplemental-graph count, OPB/PBP line counts, solution count) as a TSV at
+# $RPS_METRICS (default <workdir>/proof_sweep_metrics.tsv), for the solve-pipeline
+# refactor baseline; see dev_docs/preprocessor-refactor.md and proof_metrics.bash.
 
 set -u
 
@@ -28,6 +31,15 @@ workdir="$4"
 
 fails=0
 checked=0
+
+# Per-instance proof-size metrics for the solve-pipeline refactor baseline (see
+# dev_docs/preprocessor-refactor.md and proof_metrics.bash). Written as a TSV; the path
+# can be overridden with $RPS_METRICS.
+metrics="${RPS_METRICS:-${workdir}/proof_sweep_metrics.tsv}"
+printf 'family\tseed\topts\tshape_graphs\topb_lines\tpbp_lines\tsolutions\tverify\n' > "${metrics}"
+total_opb=0
+total_pbp=0
+recorded=0
 
 # Two families: loopless (no --loops) and loopy (--loops). Supplemental graphs are on
 # by default in both, so the exact-path / distance-3 / degree / NDS derivations are
@@ -61,14 +73,32 @@ for loops in "" "--loops 0.3"; do
                 continue
             fi
 
+            verify=ok
             if ! "${veripb}" "${proof}.opb" "${proof}.pbp" 2>&1 | grep -q 'VERIFIED'; then
                 echo "loops='${loops}' seed ${seed}, opts '${opts}': proof did NOT verify" 1>&2
                 "${veripb}" "${proof}.opb" "${proof}.pbp" 2>&1 | tail -4 1>&2
                 fails=$((fails + 1))
+                verify=FAIL
             fi
+
+            # record proof-size metrics (see proof_metrics.bash for the fixed-instance baseline)
+            family="loopless"; [ -n "${loops}" ] && family="loopy"
+            opb_lines=$(wc -l < "${proof}.opb")
+            pbp_lines=$(wc -l < "${proof}.pbp")
+            shape=$(sed -n 's/^shape_graphs = //p' "${proof}.log"); shape="${shape:-NA}"
+            sols=$(sed -n 's/^solution_count = //p' "${proof}.log")
+            [ -z "${sols}" ] && sols=$(sed -n 's/^status = //p' "${proof}.log")
+            sols="${sols:-NA}"
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+                "${family}" "${seed}" "${opts:-none}" "${shape}" "${opb_lines}" "${pbp_lines}" "${sols}" "${verify}" \
+                >> "${metrics}"
+            total_opb=$((total_opb + opb_lines))
+            total_pbp=$((total_pbp + pbp_lines))
+            recorded=$((recorded + 1))
         done
     done
 done
 
 echo "checked ${checked} random proofs, ${fails} failure(s)"
+echo "metrics: ${recorded} rows -> ${metrics} (total opb_lines=${total_opb}, pbp_lines=${total_pbp})"
 [ "${fails}" -eq 0 ]


### PR DESCRIPTION
First step of the solve-pipeline refactor (plan in `dev_docs/preprocessor-refactor.md`, added here). **Behaviour-neutral — no solver code changes**, just measurement instrumentation, so later phases have before/after numbers.

## What

- **`test-instances/proof_metrics.bash`** — a deterministic fixed-matrix harness. For each of a representative set of (instance, option) combinations it records the **supplemental-graph count** and **OPB / PBP line counts** (plus solution count and nodes), as a TSV. It runs the solver with `--prove` but **does not run VeriPB**, so it is fast and registered as the `proof_metrics` ctest **unconditionally** (every lane, including the sanitizers, where it doubles as a proof-emission smoke test over many feature combinations).
- **`random_proof_sweep.bash`** — now also emits a **per-instance proof-size TSV** (`$RPS_METRICS`, default `<workdir>/proof_sweep_metrics.tsv`) alongside its existing verify pass; exit semantics unchanged.
- **`dev_docs/preprocessor-refactor.md`** — the agreed plan: a single `SolveStep` pipeline (no preprocess/search split), the OPB stays the complete faithful encoding, S2a is achieved by static inertness/subsumption elimination (lazy OPB and lazy-on-cite PBP are both unsound), phases 0–6.

## Why these columns

The baseline already shows the targets: with supplementals on, `supplementals` emits 2168 PBP lines and `distance3` 5396, vs 136 for plain decision (S2a — most of those derivations filter nothing on dense graphs); and `induced_unsat` emits ~2400 proof lines while concluding at initialisation with zero search nodes (S2b). Phases 1–3 must hold these numbers byte-identical; Phase 4 onward should shrink them without changing solution counts.

## Testing

49/49 ctest green (48 + the new `proof_metrics`); `proof_metrics` also green under the ASan/UBSan build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)