### PR TITLE
Do not use the loop/clique shortcuts for induced mappings into loopy targets

### DIFF
--- a/gss/homomorphism.cc
+++ b/gss/homomorphism.cc
@@ -545,7 +545,9 @@ auto gss::solve_homomorphism_problem(
     }
 
     // does the target have loops, and are we looking for a single non-injective mapping?
-    if ((params.injectivity == Injectivity::NonInjective) && ! pattern.has_vertex_labels() && ! pattern.has_edge_labels() && target.loopy() && ! params.count_solutions && ! params.enumerate_callback) {
+    // (not for induced: mapping every pattern vertex onto one self-looped target vertex sends
+    // each pattern non-edge to that loop -- an edge -- which an induced mapping forbids)
+    if ((params.injectivity == Injectivity::NonInjective) && ! params.induced && ! pattern.has_vertex_labels() && ! pattern.has_edge_labels() && target.loopy() && ! params.count_solutions && ! params.enumerate_callback) {
         HomomorphismResult result;
         result.extra_stats.emplace_back("used_loops_property = true");
         result.complete = true;
@@ -564,8 +566,11 @@ auto gss::solve_homomorphism_problem(
         return result;
     }
 
-    // is the pattern a clique? if so, use a clique algorithm instead
-    if (can_use_clique(params) && is_simple_clique(pattern)) {
+    // is the pattern a clique? if so, use a clique algorithm instead. (Not for an induced
+    // mapping into a target with loops: a simple-clique pattern is loopless, so an induced
+    // mapping must avoid self-looped target vertices, but the clique algorithm ignores loops
+    // and may map a pattern vertex onto one.)
+    if (can_use_clique(params) && is_simple_clique(pattern) && ! (params.induced && target.loopy())) {
         CliqueParams clique_params;
         clique_params.timeout = params.timeout;
         clique_params.start_time = params.start_time;

--- a/gss/homomorphism_test.cc
+++ b/gss/homomorphism_test.cc
@@ -161,6 +161,82 @@ R"(1,2
     }
 }
 
+TEST_CASE("induced mapping does not misuse the loop or clique shortcuts")
+{
+    // Regression: the non-injective target-loop shortcut and the clique-pattern shortcut both
+    // ignored --induced on a loopy target, returning mappings that send a loopless pattern
+    // vertex (or a pattern non-edge) onto a target self-loop, which an induced mapping forbids.
+
+    SECTION("target-loop shortcut is not used for an induced mapping")
+    {
+        // Two isolated (loopless) pattern vertices; the only target vertex has a self-loop. The
+        // non-injective loop shortcut would map both onto the loop, but no loopless pattern
+        // vertex can map onto a looped target vertex under an induced mapping.
+        auto pattern = read_csv(stringstream{"a,\nc,\n"}, "pattern");
+        auto target = read_csv(stringstream{"1,1\n"}, "target");
+
+        HomomorphismParams params;
+        params.timeout = make_shared<Timeout>(0s);
+        params.restarts_schedule = make_unique<NoRestartsSchedule>();
+        params.injectivity = Injectivity::NonInjective;
+        params.induced = true;
+
+        auto decided = solve_homomorphism_problem(pattern, target, params);
+        CHECK(decided.mapping.empty());
+        CHECK(decided.complete);
+
+        params.count_solutions = true;
+        auto counted = solve_homomorphism_problem(pattern, target, params);
+        CHECK(counted.solution_count == 0);
+    }
+
+    SECTION("clique shortcut is not used for an induced mapping into a loopy target")
+    {
+        // A K2 pattern is a simple (loopless) clique; the target's vertices all have self-loops.
+        // The clique algorithm would find the K2, but its loopless endpoints cannot map onto
+        // looped target vertices under an induced mapping.
+        auto pattern = read_csv(stringstream{"a,b\n"}, "pattern");
+        auto target = read_csv(stringstream{"1,2\n1,1\n2,2\n"}, "target");
+
+        HomomorphismParams params;
+        params.timeout = make_shared<Timeout>(0s);
+        params.restarts_schedule = make_unique<NoRestartsSchedule>();
+        params.clique_detection = true;
+        params.induced = true;
+
+        auto decided = solve_homomorphism_problem(pattern, target, params);
+        CHECK(decided.mapping.empty());
+        CHECK(decided.complete);
+
+        params.count_solutions = true;
+        auto counted = solve_homomorphism_problem(pattern, target, params);
+        CHECK(counted.solution_count == 0);
+    }
+
+    SECTION("clique shortcut is still used for an induced mapping into a loopless target")
+    {
+        // The fix must not disable the optimisation in the common case: a K2 pattern into a
+        // loopless K3 target has induced solutions and should still go through the clique
+        // algorithm.
+        auto pattern = read_csv(stringstream{"a,b\n"}, "pattern");
+        auto target = read_csv(stringstream{"1,2\n1,3\n2,3\n"}, "target");
+
+        HomomorphismParams params;
+        params.timeout = make_shared<Timeout>(0s);
+        params.restarts_schedule = make_unique<NoRestartsSchedule>();
+        params.clique_detection = true;
+        params.induced = true;
+
+        auto decided = solve_homomorphism_problem(pattern, target, params);
+        CHECK(! decided.mapping.empty());
+        bool used_clique_solver = false;
+        for (auto & stat : decided.extra_stats)
+            if (stat == "used_clique_solver = true")
+                used_clique_solver = true;
+        CHECK(used_clique_solver);
+    }
+}
+
 TEST_CASE("homomorphism loop shrinking")
 {
     auto pattern = read_csv(stringstream{// clang-format off


### PR DESCRIPTION
## Problem

Two early-out shortcuts in `solve_homomorphism_problem` ignore `--induced` when the target has self-loops, returning mappings that an induced homomorphism forbids:

- **Target-loop shortcut** (non-injective): maps every pattern vertex onto a single self-looped target vertex. Valid for a plain homomorphism, but under an induced mapping a pattern *non-edge* between two such vertices is sent to that loop (an edge), so the mapping is invalid.
- **Clique-pattern shortcut**: hands the problem to the clique algorithm, which ignores loops. A simple-clique pattern is loopless, so an induced mapping must send its vertices to loopless target vertices, but the clique algorithm may pick self-looped ones.

Both only fire in decision mode (counting disables them), so they returned a spurious *satisfiable* while counting the same instance correctly gave **zero** — i.e. decision and count disagreed. Minimal repros:

- clique: 1-vertex (loopless) pattern → 1 self-looped target vertex, `--induced` → reported SAT, should be UNSAT.
- loop: two isolated pattern vertices → 1 self-looped target vertex, `--noninjective --induced` → reported SAT, should be UNSAT.

## Fix

- Guard the loop shortcut with `! params.induced`.
- Guard the clique shortcut with `! (params.induced && target.loopy())` — this keeps the optimisation for the common **induced, loopless-target** case (verified still used).

## Tests

New `homomorphism_test.cc` case `induced mapping does not misuse the loop or clique shortcuts` with three sections: the two repros (now UNSAT, decision agrees with count) plus a positive case (induced K2 → loopless K3 still goes through the clique algorithm). Full ctest passes (41/41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Rebased onto #69

Restacked on `pipeline/refactor`. The fix had to be **redone rather than replayed**: #69 turns these
two shortcuts into pipeline steps, so the guards now live in `TargetLoopShortcutStep::run` and
`CliqueShortcutStep::run` instead of the old inline `if` blocks. The conditions themselves are
unchanged.

Re-verified on the new base: `ctest` 42/42 (49 with `cake_pb_iso`), the new regression test passes,
both repros now report UNSAT in decision mode and agree with the count, and both shortcuts still fire
where they legitimately apply (induced K2 → loopless K3 still reports `used_clique_solver = true`;
non-induced non-injective into a loopy target still reports `used_loops_property = true`).
