### PR TITLE
Emit supplemental-graph adjacency constraints lazily

### DIFF
--- a/gss/innards/homomorphism_model.cc
+++ b/gss/innards/homomorphism_model.cc
@@ -642,6 +642,11 @@ auto HomomorphismModel::target_vertex_for_proof(int v) const -> NamedVertex
     return _imp->proofs->target_vertex(v);
 }
 
+auto HomomorphismModel::proofs() const -> HomomorphismProofs *
+{
+    return _imp->proofs;
+}
+
 auto HomomorphismModel::prepare() -> bool
 {
     if (is_nonshrinking(_imp->params) && (pattern_size > target_size))

--- a/gss/innards/homomorphism_model.hh
+++ b/gss/innards/homomorphism_model.hh
@@ -50,6 +50,10 @@ namespace gss::innards
         auto pattern_vertex_for_proof(int v) const -> NamedVertex;
         auto target_vertex_for_proof(int v) const -> NamedVertex;
 
+        // The solver-proofs middle layer (nullptr when not proving), so the searcher can
+        // drive lazy supplemental materialisation on assignment / forward-check removal.
+        [[nodiscard]] auto proofs() const -> HomomorphismProofs *;
+
         auto prepare() -> bool;
 
         // Build the supplemental graphs (exact-path, distance-3, …) into their slots and,

--- a/gss/innards/homomorphism_proofs.cc
+++ b/gss/innards/homomorphism_proofs.cc
@@ -52,6 +52,47 @@ auto HomomorphismProofs::target_vertex(int v) const -> NamedVertex
     return pair{v, _target_names[v]};
 }
 
+auto HomomorphismProofs::register_supplemental(const std::tuple<long, long, long, long> & key, int p, int t,
+    std::function<void()> emit) -> void
+{
+    if (_pending_supplementals.contains(key) || _proof->adjacency_proof_lines().labels.contains(key))
+        return;
+    _pending_supplementals.emplace(key, move(emit));
+    _pending_by_antecedent[pair<int, int>{p, t}].push_back(key);
+}
+
+auto HomomorphismProofs::materialise_one(const std::tuple<long, long, long, long> & key) -> bool
+{
+    auto it = _pending_supplementals.find(key);
+    if (it == _pending_supplementals.end())
+        return false;
+    auto emit = move(it->second);
+    _pending_supplementals.erase(it);
+    emit();
+    return true;
+}
+
+auto HomomorphismProofs::materialise_adjacency_for(int p, int t) -> void
+{
+    auto it = _pending_by_antecedent.find(pair<int, int>{p, t});
+    if (it == _pending_by_antecedent.end())
+        return;
+    auto keys = move(it->second);
+    _pending_by_antecedent.erase(it);
+    // each emit leaves the proof at level 0 (where the @label persists); restore the
+    // search's active level once for the whole batch rather than once per supplemental.
+    bool emitted_any = false;
+    for (auto & key : keys)
+        emitted_any = materialise_one(key) || emitted_any;
+    if (emitted_any && _proof->active_level() != 0)
+        _proof->emit_proof_directive("setlvl " + std::to_string(_proof->active_level()) + ";");
+}
+
+auto HomomorphismProofs::has_pending_supplementals() const -> bool
+{
+    return ! _pending_supplementals.empty();
+}
+
 auto HomomorphismProofs::emit_adjacency_constraint(int p, int q, int t, const std::vector<int> & permitted) -> void
 {
     std::string adj_label = "@adj" + _pattern_names[p] + "_" + _target_names[t] + "_" + _pattern_names[q];
@@ -88,7 +129,12 @@ auto HomomorphismProofs::emit_exact_path_graph(int g, int p, int q, const std::v
     _proof->emit_proof_directive("% adjacency " + _pattern_names[p] + " maps to " + _target_names[t] +
         " in G^[" + std::to_string(g) + "x2] so " + _pattern_names[q] + " maps to one of...");
 
-    _proof->emit_proof_directive("setlvl 1;");
+    // Scratch one level above the search: wiplvl wipes every level >= its argument (that is
+    // how forget_level discards a search subtree), so a hardcoded level 1 would wipe the whole
+    // search trail when materialising mid-search. The @label is emitted at level 0 below so it
+    // persists; the caller restores the search level.
+    int scratch = _proof->active_level() + 1;
+    _proof->emit_proof_directive("setlvl " + std::to_string(scratch) + ";");
 
     // if p maps to t then things in between_p_and_q have to go to one of these, and then go
     // two hops out cancelling between_p_and_q things with where q can go
@@ -191,7 +237,7 @@ auto HomomorphismProofs::emit_exact_path_graph(int g, int p, int q, const std::v
     _proof->emit_proof_line(adj_label + " ia " + tidied_up + " " + std::to_string(_proof->current_proof_line()) + " ;");
     adjacency.labels.emplace(std::tuple<long, long, long, long>{g, p, q, t}, adj_label);
     _proof->cache_proof_line(tidied_up, adj_label);
-    _proof->emit_proof_directive("wiplvl 1;");
+    _proof->emit_proof_directive("wiplvl " + std::to_string(scratch) + ";");
 }
 
 auto HomomorphismProofs::prove_exact_path_graphs(const ProcessedGraphsData & graphs, unsigned max_graphs,
@@ -267,8 +313,11 @@ auto HomomorphismProofs::prove_exact_path_graphs(const ProcessedGraphsData & gra
                         two_away_from_t.emplace_back(int(w), n_t_w_idx);
                     }
 
-                    emit_exact_path_graph(int(slot), int(p), int(q), between_p_and_q,
-                        int(t), n_t, two_away_from_t, d_n_t);
+                    int slot_i = int(slot), p_i = int(p), q_i = int(q), t_i = int(t);
+                    register_supplemental(std::tuple<long, long, long, long>{slot_i, p_i, q_i, t_i}, p_i, t_i,
+                        [this, slot_i, p_i, q_i, t_i, between_p_and_q, n_t, two_away_from_t, d_n_t]() {
+                            emit_exact_path_graph(slot_i, p_i, q_i, between_p_and_q, t_i, n_t, two_away_from_t, d_n_t);
+                        });
                 }
             }
         }
@@ -284,6 +333,9 @@ auto HomomorphismProofs::emit_distance3_graph_distance_1(int g, int p, int q, in
     _proof->emit_proof_directive("% adjacency " + _pattern_names[p] + " maps to " + _target_names[t] +
         " in G^3 so by adjacency, " + _pattern_names[q] + " maps to one of...");
 
+    // single-line derivation: emit the @label at the top level so it persists across search
+    // backtracking (the caller restores the active level for the batch).
+    _proof->emit_proof_directive("setlvl 0;");
     std::string adj_label = "@d3adj" + _pattern_names[p] + "_" + _target_names[t] + "_" + _pattern_names[q];
     std::string line = adj_label + " ia 1 ~x" + _proof->variable_name(p, t);
     for (auto & u : d3_from_t)
@@ -302,7 +354,9 @@ auto HomomorphismProofs::emit_distance3_graph_distance_2(int g, int p, int q, in
     _proof->emit_proof_directive("% adjacency " + _pattern_names[p] + " maps to " + _target_names[t] +
         " in G^3 so using vertex " + _pattern_names[path1] + ", " + _pattern_names[q] + " maps to one of...");
 
-    _proof->emit_proof_directive("setlvl 1;");
+    // scratch one level above the search (see emit_exact_path_graph).
+    int scratch = _proof->active_level() + 1;
+    _proof->emit_proof_directive("setlvl " + std::to_string(scratch) + ";");
 
     // if p maps to t then the first thing on the path from p to q has to go to one of, so the
     // second thing on the path from p to q has to go to one of...
@@ -329,6 +383,9 @@ auto HomomorphismProofs::emit_distance3_graph_distance_2(int g, int p, int q, in
     _proof->emit_proof_line(line);
 
     adjacency.labels.emplace(std::tuple<long, long, long, long>{g, p, q, t}, adj_label);
+    // self-clean the scratch (lazy ordering means we can't rely on a later supplemental's
+    // wiplvl); the @label is at level 0, and the caller restores the search's active level.
+    _proof->emit_proof_directive("wiplvl " + std::to_string(scratch) + ";");
 }
 
 auto HomomorphismProofs::emit_distance3_graph(int g, int p, int q, int path1, int path2, int t,
@@ -340,7 +397,9 @@ auto HomomorphismProofs::emit_distance3_graph(int g, int p, int q, int path1, in
         " in G^3 so using path " + _pattern_names[path1] + " -- " + _pattern_names[path2] + ", " +
         _pattern_names[q] + " maps to one of...");
 
-    _proof->emit_proof_directive("setlvl 1;");
+    // scratch one level above the search (see emit_exact_path_graph).
+    int scratch = _proof->active_level() + 1;
+    _proof->emit_proof_directive("setlvl " + std::to_string(scratch) + ";");
 
     // if p maps to t then the first thing on the path from p to q has to go to one of, so the
     // second thing on the path from p to q has to go to one of...
@@ -373,6 +432,9 @@ auto HomomorphismProofs::emit_distance3_graph(int g, int p, int q, int path1, in
     _proof->emit_proof_line(line);
 
     adjacency.labels.emplace(std::tuple<long, long, long, long>{g, p, q, t}, adj_label);
+    // self-clean the scratch (lazy ordering means we can't rely on a later supplemental's
+    // wiplvl); the @label is at level 0, and the caller restores the search's active level.
+    _proof->emit_proof_directive("wiplvl " + std::to_string(scratch) + ";");
 }
 
 auto HomomorphismProofs::prove_distance3_graphs(const ProcessedGraphsData & graphs, unsigned max_graphs, unsigned slot,
@@ -466,14 +528,19 @@ auto HomomorphismProofs::prove_distance3_graphs(const ProcessedGraphsData & grap
                 d2_from_t.assign(d2_from_t_set.begin(), d2_from_t_set.end());
                 d3_from_t.assign(d3_from_t_set.begin(), d3_from_t_set.end());
 
-                if (actually_adjacent)
-                    emit_distance3_graph_distance_1(int(slot), int(p), int(q), int(t), d3_from_t);
-                else if (path_from_p_to_q_2)
-                    emit_distance3_graph(int(slot), int(p), int(q), *path_from_p_to_q_1,
-                        *path_from_p_to_q_2, int(t), d1_from_t, d2_from_t, d3_from_t);
-                else
-                    emit_distance3_graph_distance_2(int(slot), int(p), int(q), *path_from_p_to_q_1,
-                        int(t), d1_from_t, d2_from_t, d3_from_t);
+                int slot_i = int(slot), p_i = int(p), q_i = int(q), t_i = int(t);
+                bool adj = actually_adjacent;
+                int path1 = path_from_p_to_q_1.value_or(-1);
+                optional<int> path2 = path_from_p_to_q_2;
+                register_supplemental(std::tuple<long, long, long, long>{slot_i, p_i, q_i, t_i}, p_i, t_i,
+                    [this, slot_i, p_i, q_i, t_i, adj, path1, path2, d1_from_t, d2_from_t, d3_from_t]() {
+                        if (adj)
+                            emit_distance3_graph_distance_1(slot_i, p_i, q_i, t_i, d3_from_t);
+                        else if (path2)
+                            emit_distance3_graph(slot_i, p_i, q_i, path1, *path2, t_i, d1_from_t, d2_from_t, d3_from_t);
+                        else
+                            emit_distance3_graph_distance_2(slot_i, p_i, q_i, path1, t_i, d1_from_t, d2_from_t, d3_from_t);
+                    });
             }
         }
     }
@@ -483,6 +550,9 @@ auto HomomorphismProofs::emit_shape_graph(int g, int p, int q, int t, const std:
 {
     _proof->emit_proof_directive("% adjacency " + _pattern_names[p] + " maps to " + _target_names[t] +
         " in shape graph " + std::to_string(g) + " so " + _pattern_names[q] + " maps to one of...");
+    // single-line assertion: emit the @label at the top level so it persists across search
+    // backtracking (the caller restores the active level for the batch).
+    _proof->emit_proof_directive("setlvl 0;");
     std::string adj_label = "@g" + std::to_string(g) + "adj" + _pattern_names[p] + "_" + _target_names[t] + "_" + _pattern_names[q];
     std::string line = adj_label + " a 1 ~x" + _proof->variable_name(p, t);
     for (auto & u : n_t)
@@ -511,7 +581,11 @@ auto HomomorphismProofs::prove_extra_shape(const ProcessedGraphsData & graphs, u
                     n_t_row.reset(v);
                     n_t.push_back(int(v));
                 }
-                emit_shape_graph(int(slot), int(p), int(q), int(t), n_t);
+                int slot_i = int(slot), p_i = int(p), q_i = int(q), t_i = int(t);
+                register_supplemental(std::tuple<long, long, long, long>{slot_i, p_i, q_i, t_i}, p_i, t_i,
+                    [this, slot_i, p_i, q_i, t_i, n_t]() {
+                        emit_shape_graph(slot_i, p_i, q_i, t_i, n_t);
+                    });
             }
         }
     }
@@ -744,6 +818,9 @@ auto HomomorphismProofs::ensure_supplemental_adjacency(const ProcessedGraphsData
 {
     // present already (it is the kept constraint, the original graph, or elision is off): nothing to do.
     auto & adjacency = _proof->adjacency_proof_lines();
+    // with lazy emission the kept constraint for this head may still be pending; if (g,p,q,t)
+    // is itself the kept one, materialising it makes it present and we are done.
+    materialise_one(std::tuple<long, long, long, long>{g, p, q, t});
     if (adjacency.labels.contains(std::tuple<long, long, long, long>{g, p, q, t}))
         return;
 
@@ -759,6 +836,8 @@ auto HomomorphismProofs::ensure_supplemental_adjacency(const ProcessedGraphsData
     // narrower target set). The wider graph-g constraint follows from the narrower by a single
     // implication step, so derive it that way, citing the kept constraint by its label.
     int from_g = int(kept->second);
+    // the kept (stronger) constraint we weaken from may itself still be pending; emit it first.
+    materialise_one(std::tuple<long, long, long, long>{from_g, p, q, t});
     auto from_label = adjacency.labels.at(std::tuple<long, long, long, long>{from_g, p, q, t});
     std::string adj_label = "@g" + std::to_string(g) + "adj" + _pattern_names[p] + "_" + _target_names[t] + "_" + _pattern_names[q];
     std::string line = adj_label + " ia 1 ~x" + _proof->variable_name(p, t);

--- a/gss/innards/homomorphism_proofs.hh
+++ b/gss/innards/homomorphism_proofs.hh
@@ -6,6 +6,7 @@
 #include <gss/innards/processed_graphs_data.hh>
 #include <gss/innards/proof.hh>
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <set>
@@ -39,6 +40,23 @@ namespace gss::innards
         // Supplemental adjacency lines created transiently for a degree/NDS check, to delete
         // once it is done.
         std::vector<std::tuple<int, int, int, int>> _pending_transient_adjacencies;
+
+        // Lazy emission: the kept (post-subsumption) supplemental adjacency derivations are
+        // registered here rather than emitted up front, and materialised on first use -- a
+        // degree/NDS root read, an assignment of x_p_t, or a forward-check removal of t from
+        // dom(p). A supplemental for antecedent (p,t) is needed only when x_p_t's value is
+        // decided by adjacency during search, so a head never touched is never emitted.
+        // pending_supplementals maps the constraint key (g,p,q,t) to its emit closure;
+        // pending_by_antecedent indexes those keys by antecedent (p,t).
+        std::map<std::tuple<long, long, long, long>, std::function<void()>> _pending_supplementals;
+        std::map<std::pair<int, int>, std::vector<std::tuple<long, long, long, long>>> _pending_by_antecedent;
+
+        // Register a supplemental derivation to be emitted lazily (no-op if already pending
+        // or already emitted): key is (g,p,q,t), antecedent is (p,t).
+        auto register_supplemental(const std::tuple<long, long, long, long> & key, int p, int t,
+            std::function<void()> emit) -> void;
+        // Run the pending derivation for one key (idempotent); true iff it emitted.
+        auto materialise_one(const std::tuple<long, long, long, long> & key) -> bool;
 
         // Derive the exact-path (G^[gx2]) adjacency constraint for one head: "p maps to t
         // implies q maps to a vertex reachable from t by enough 2-walks". g is the slot the
@@ -128,6 +146,17 @@ namespace gss::innards
             int g, int p, int q, int t) -> void;
         // Delete every adjacency line ensure_supplemental_adjacency created since the last call.
         auto forget_transient_supplemental_adjacencies() -> void;
+
+        // Materialise every pending supplemental adjacency derivation whose antecedent is
+        // (p,t). The searcher calls this when p->t is assigned (branch or unit propagation)
+        // and when forward-checking removes t from dom(p). Mid-search the derivations scratch
+        // one level above the search and the @label persists at level 0; this restores the
+        // search's active level once for the batch.
+        auto materialise_adjacency_for(int p, int t) -> void;
+
+        // Whether any supplemental is still pending; lets the searcher skip its per-removal
+        // bookkeeping once everything has been materialised.
+        [[nodiscard]] auto has_pending_supplementals() const -> bool;
 
         // Prove that pattern vertex p cannot map to target tt, because p sits in a bigger
         // clique (in graph pair g) than tt does. Runs the clique solver with proof

--- a/gss/innards/homomorphism_searcher.cc
+++ b/gss/innards/homomorphism_searcher.cc
@@ -1,4 +1,5 @@
 #include <gss/innards/cheap_all_different.hh>
+#include <gss/innards/homomorphism_proofs.hh>
 #include <gss/innards/homomorphism_searcher.hh>
 
 #include <optional>
@@ -162,8 +163,13 @@ auto HomomorphismSearcher::restarting_search(
 
     // for each value remaining...
     for (auto f_v = branch_v.begin(), f_end = branch_v.begin() + branch_v_end; f_v != f_end; ++f_v) {
-        if (proof)
+        if (proof) {
             proof->guessing(depth, model.pattern_vertex_for_proof(branch_domain->v), model.target_vertex_for_proof(*f_v));
+            // branching on branch_v->*f_v forward-checks using its supplemental adjacency; emit
+            // any still-pending supplemental for this antecedent before the propagation.
+            if (auto hp = model.proofs())
+                hp->materialise_adjacency_for(int(branch_domain->v), int(*f_v));
+        }
 
         // modified in-place by appending, we can restore by shrinking
         auto assignments_size = assignments.values.size();
@@ -364,6 +370,15 @@ auto HomomorphismSearcher::propagate_adjacency_constraints(HomomorphismDomain & 
 {
     const auto & graph_pairs_to_consider = model.pattern_adjacency_bits(current_assignment.pattern_vertex, d.v);
 
+    // Lazy supplemental proofs: every value this forward-check removes from dom(d.v) is an
+    // adjacency-based elimination whose branch-consequence a later Hall confinement may cite,
+    // so materialise the supplemental for (d.v, removed value) below. Snapshot dom(d.v) now;
+    // skipped once nothing is left to defer (or with proofs off).
+    const bool lazy_proof = proof && model.proofs() && model.proofs()->has_pending_supplementals();
+    SVOBitset lazy_proof_before;
+    if (lazy_proof)
+        lazy_proof_before = d.values;
+
     [[maybe_unused]] conditional_t<verbose_proofs_, SVOBitset, tuple<>> before;
     if constexpr (verbose_proofs_) {
         before = d.values;
@@ -459,6 +474,17 @@ auto HomomorphismSearcher::propagate_adjacency_constraints(HomomorphismDomain & 
                 if (got_reverse_label != want_reverse_label)
                     d.values.reset(c);
             }
+        }
+    }
+
+    if (lazy_proof) {
+        auto removed = lazy_proof_before;
+        removed.intersect_with_complement(d.values); // before & ~after = removed values
+        for (auto c = removed.find_first(); c != decltype(removed)::npos; c = removed.find_first()) {
+            removed.reset(c);
+            // pattern_vertex_for_proof / target_vertex_for_proof are the identity on the index,
+            // so (d.v, c) is already the proof-space (p, t) antecedent.
+            model.proofs()->materialise_adjacency_for(int(d.v), int(c));
         }
     }
 }
@@ -753,10 +779,14 @@ auto HomomorphismSearcher::propagate(bool initial, Domains & new_domains, Homomo
             branch_domain->fixed = true;
             assignments.values.push_back({*current_assignment, false, -1, -1});
 
-            if (proof)
+            if (proof) {
                 proof->unit_propagating(
                     model.pattern_vertex_for_proof(current_assignment->pattern_vertex),
                     model.target_vertex_for_proof(current_assignment->target_vertex));
+                // a forced var->val also forward-checks using its supplemental adjacency.
+                if (auto hp = model.proofs())
+                    hp->materialise_adjacency_for(int(current_assignment->pattern_vertex), int(current_assignment->target_vertex));
+            }
 
             // propagate watches
             if (might_have_watches(params)) {

--- a/gss/innards/proof.cc
+++ b/gss/innards/proof.cc
@@ -638,6 +638,11 @@ auto Proof::current_proof_line() const -> long
     return _imp->proof_line;
 }
 
+auto Proof::active_level() const -> int
+{
+    return _imp->active_level;
+}
+
 auto Proof::variable_name(int p, int t) const -> const string &
 {
     return _imp->variable_mappings.at(pair<long, long>{p, t});

--- a/gss/innards/proof.hh
+++ b/gss/innards/proof.hh
@@ -96,6 +96,10 @@ namespace gss::innards
         auto emit_proof_line(const std::string & line) -> long;
         auto emit_proof_directive(const std::string & line) -> void;
         [[nodiscard]] auto current_proof_line() const -> long;
+        // The currently active proof level (0 at the root, depth+2 during search). The
+        // middle layer uses this to scratch one level above the search when materialising a
+        // supplemental derivation mid-search (wiplvl wipes every level >= its argument).
+        [[nodiscard]] auto active_level() const -> int;
         [[nodiscard]] auto variable_name(int p, int t) const -> const std::string &;
         [[nodiscard]] auto is_locally_injective() const -> bool;
 


### PR DESCRIPTION
Builds on the branch's existing supplemental-proof economy — subsumption elision (Phase 4) and the transient `ensure`/`forget` mechanism (Phase 5) — by **deferring** the kept-strongest supplemental adjacency derivations until first use, rather than emitting them all during model build.

### What lazy adds (orthogonal to subsumption)
A supplemental for antecedent `(p,t)` is needed only when `x_p_t`'s value is decided *by adjacency* during search:
- **assigned true** — the forward-checking use;
- **removed from `dom(p)` by forward-checking** — the branch-consequence a later Hall-set confinement cites in its RUP;

plus the root **degree/NDS** reads. So a head never touched during search is never emitted. This is orthogonal to subsumption (which picks the strongest constraint *per head*) and composes with it: subsumption thins each head to one constraint; lazy drops the heads that never matter.

(Established empirically in the master-based investigation: keeping supplementals only for *assigned* `(p,t)` fails `--distance3` proofs — the checker's RUP reconstructs a Hall confinement via the *removed* vertices' adjacency in reverse — whereas keying on assignment ∪ removal verifies.)

### Implementation
Re-designed into the `HomomorphismProofs` middle layer:
- `prove_exact_path_graphs` / `prove_distance3_graphs` / `prove_extra_shape` keep their analysis eager (the subsumption `covered` set + `_kept_supplemental_slot`) but **register a pending closure** per kept constraint instead of emitting.
- `materialise_adjacency_for` runs them on first use, driven from the searcher's `guessing` / `unit_propagating` (assignment) and `propagate_adjacency_constraints` (per removed value, gated on `has_pending_supplementals()`), reaching the proof layer via a new `HomomorphismModel::proofs()`.
- `ensure_supplemental_adjacency` now materialises the **kept** constraint it weakens from — it may still be pending when a degree/NDS check reads it.

Mid-search materialisation scratches one level above the search (`active_level+1`, since `wiplvl N` wipes every level ≥ N), emits the persistent `@label` at level 0, and restores the active level once per batch (new `Proof::active_level()` getter).

The OPB is **byte-identical** and the search tree is unchanged; only PBP logging differs.

### Results
- **ctest 49/49** under release and sanitize (ASan+UBSan), incl. `proof_*`, the `cake_*` verified pipeline, and `random_proof_sweep`.
- A **300-instance** distance-3 / locally-injective / counting sweep verifies; `--cliques --distance3`, `--k4`, `--shape` smoke-tested.
- **OPB byte-identical** to the branch tip.
- On top of subsumption it roughly **halves** the supplemental count and PBP lines again:

| instance | subsumption-only | + lazy |
|---|---|---|
| seed-31 6v→9v `--distance3` | 279 supp / 3479 lines | **117 / 1423** |
| 7v→10v `--distance3` | 392 / 4588 | **123 / 1631** |
| 6v→9v `--distance3` | 270 / 2245 | **160 / 1444** |

Pre-existing and unaffected (avoid in proof runs): directed distance-3 proofs throw at model build; labelled proofs are explicitly unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)